### PR TITLE
fix(blog-app): include .vercel/output in Nx build outputs (fix Vercel deploy on cache hit)

### DIFF
--- a/apps/blog-app/project.json
+++ b/apps/blog-app/project.json
@@ -24,7 +24,7 @@
           "mode": "production"
         }
       },
-      "outputs": ["{workspaceRoot}/dist/apps/blog-app"]
+      "outputs": ["{workspaceRoot}/dist/apps/blog-app", "{workspaceRoot}/.vercel/output"]
     },
     "serve": {
       "executor": "@analogjs/platform:vite-dev-server",


### PR DESCRIPTION
## Problem

Vercel production deploy fails with:

> Error: No Output Directory named \"static\" found after the Build completed.

The build log shows the trigger:

> Nx read the output from the cache instead of running the command for 1 out of 1 tasks.

## Root cause

`apps/blog-app/vite.config.ts` sets `nitro: { preset: 'vercel' }`, so every production build emits the **Build Output API** artifact to `{workspaceRoot}/.vercel/output`. But the Nx `build` target only declared `{workspaceRoot}/dist/apps/blog-app` in its `outputs`.

- **Cache miss** (PR previews) → build runs, `.vercel/output` written fresh → Vercel finds it ✅
- **Cache hit** (this deploy) → Nx restores only `dist/...`, **not** `.vercel/output` → Vercel finds no output ❌

## Fix

Add `{workspaceRoot}/.vercel/output` to the build target `outputs` so Nx caches and restores it.

```diff
-      "outputs": ["{workspaceRoot}/dist/apps/blog-app"]
+      "outputs": ["{workspaceRoot}/dist/apps/blog-app", "{workspaceRoot}/.vercel/output"]
```

## Verification (local repro of the Vercel scenario)

1. `nx build blog-app` → cache miss, `.vercel/output` produced ✅
2. `rm -rf .vercel/output dist/apps/blog-app` (simulate fresh checkout)
3. `nx build blog-app` → `[local cache]` "Nx read the output from the cache" → **`.vercel/output` restored** ✅

The config change also bumps the task hash, so the first post-merge deploy rebuilds fresh and repopulates the cache correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build output configuration to support additional deployment paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->