### PR TITLE
chore(skills): interactive-blog-content skill + wire it into blog-post-manager

### DIFF
--- a/.claude/agents/blog-post-manager.md
+++ b/.claude/agents/blog-post-manager.md
@@ -57,6 +57,12 @@ You are an expert Analog (Angular) blog content manager with deep expertise in m
   ```
 - The `coverImage` frontmatter field uses a full absolute URL: `https://dalenguyen.me/assets/images/blog/<filename>`
 
+**Interactive Content (charts, sliders, diagrams, widgets)**:
+
+- When a post should include anything the reader can interact with — live charts, a slider/calculator, a toggle, an animated or step-through diagram, or any custom widget — **invoke the `interactive-blog-content` skill and follow it**. Do NOT hand-roll a mounting mechanism or rely on inline `<script>` (inline scripts never run in the rendered markdown).
+- That skill documents the project's architecture: a `<div data-chart="key">fallback</div>` placeholder in the markdown, a co-located `src/content/<slug>/charts.ts` manifest, glob auto-discovery, and dynamic component mounting — plus the reusable `BarChartComponent` and the critical gotchas (escape raw tags as `&lt;`/`&gt;` inside inline code or the post truncates; use `ViewEncapsulation.ShadowDom` with the dark palette; keep it SSR-safe; clean up timers in `ngOnDestroy`).
+- Keep each post self-contained: every component, data file, and the manifest live in the co-located `src/content/<slug>/` folder. No central registry needs editing.
+
 **Content Quality Standards**:
 
 - Use clear, concise, and technically accurate language

--- a/.claude/skills/interactive-blog-content/SKILL.md
+++ b/.claude/skills/interactive-blog-content/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: interactive-blog-content
+description: >-
+  This skill should be used when adding interactive elements — charts, sliders,
+  step-through diagrams, or any custom Angular widget — to a markdown blog post in
+  apps/blog-app (the AnalogJS blog on dalenguyen.me). It documents the placeholder +
+  co-located manifest + glob auto-discovery + dynamic-mount architecture, the reusable
+  BarChartComponent, and the non-obvious gotchas (escaping inline tags, ShadowDom,
+  SSR-safety) needed to ship a working interactive post.
+---
+
+# Interactive Blog Content
+
+## Overview
+
+Markdown posts in `apps/blog-app/src/content/*.md` are rendered by `<analog-markdown>`.
+Raw HTML survives (it is passed through `bypassSecurityTrustHtml`) but inline `<script>`
+never runs, so interactivity is achieved by **mounting real Angular components into
+placeholder elements after the markdown renders**.
+
+The mechanism is already built and shared — do not reinvent it. Each post stays
+self-contained: a `<slug>.md` plus an adjacent `<slug>/` folder holding its components,
+data, and a `charts.ts` manifest. A glob auto-discovers manifests, so **no central file
+is ever edited** when adding a new interactive post.
+
+## When to use
+
+Use this skill whenever a blog post in `apps/blog-app` needs something the reader can
+interact with: live charts, a slider/calculator, a toggle, an animated or step-through
+diagram, or any bespoke widget. For static posts (text, images, code blocks only), this
+skill is unnecessary.
+
+## The three-step recipe
+
+1. **Placeholder** — in the `.md`, drop an empty div with a `data-chart` key and a
+   plain-text fallback (shown with no JS / before mount):
+   ```html
+   <div data-chart="speed">Chart: decode speed by prompt length. Enable JavaScript to view.</div>
+   ```
+
+2. **Manifest** — in the co-located folder `src/content/<slug>/`, create `charts.ts` whose
+   default export maps each `data-chart` key to a component (and optional `inputs`):
+   ```ts
+   import { BarChartComponent } from '../../app/blog/charts/bar-chart.component'
+   import { ChartManifest } from '../../app/blog/charts/mount-charts'
+   import { speedConfig } from './speed.data'
+   import { MyWidgetComponent } from './my-widget.component'
+
+   const manifest: ChartManifest = {
+     speed: { component: BarChartComponent, inputs: { config: speedConfig } },
+     'my-key': { component: MyWidgetComponent },
+   }
+   export default manifest
+   ```
+
+3. **Done** — `mount-charts.ts` discovers the manifest via
+   `import.meta.glob('/src/content/*/charts.ts')`; the `[slug]` route mounts the components
+   after render. Nothing else to wire.
+
+## Two paths for the component
+
+- **Reuse the shared chart** — for bar charts, reuse
+  `src/app/blog/charts/bar-chart.component.ts` and only author data: a co-located
+  `*.data.ts` exporting a `BarChartConfig` (type in `src/app/blog/charts/chart.types.ts`).
+  Supports single-series and grouped series, an optional metric toggle, and tooltips.
+- **Bespoke component** — for anything else, write a standalone Angular component in the
+  post folder. See `references/component-templates.md` for a ready-to-adapt ShadowDom,
+  signal-based skeleton.
+
+## Gotchas (read before authoring — each has bitten this codebase)
+
+- **Escape raw tags in INLINE code.** The markdown renderer emits inline-code content
+  *unescaped*, so a single-backtick `` `<script>` `` becomes a live element that swallows
+  the rest of the article (the post silently cuts off at that point). Inside single-backtick
+  spans write entities: `` `&lt;script&gt;` `` , `` `&lt;div&gt;` `` , `` `&lt;slug&gt;` ``.
+  Fenced code blocks (```` ``` ````) are Prism-escaped and safe as-is — use them for
+  multi-line examples and to demonstrate tags.
+- **Style isolation = ShadowDom.** Bespoke components must use
+  `encapsulation: ViewEncapsulation.ShadowDom` so the light article CSS (and inherited
+  `text-center`/`text-lg`) cannot leak in. Tradeoff: global Tailwind utilities cannot cross
+  the shadow boundary, so components **self-style** with the dark "figure card" palette
+  (bg `#161b22`, border `#30363d`, accent `#7c9cff`, text `#e6edf3`, muted `#9aa7b5`,
+  darker `#0b0f16`).
+- **tsconfig include.** `apps/blog-app/tsconfig.app.json` already includes
+  `src/content/**/*.ts` and `src/app/blog/**/*.ts`. These are required because
+  `import.meta.glob` is not statically resolvable; do not remove them, or content `.ts`
+  files are served untranspiled (`Missing initializer in const declaration`).
+- **SSR-safe.** Mounting is browser-only; during prerender the fallback text is what ships
+  (good for SEO / no-JS). Do not access `window`/`document` at construction time.
+- **Clean up side effects.** Any component using `setInterval`/`setTimeout`/listeners must
+  clear them in `ngOnDestroy` — the route detaches and destroys mounted views on navigation.
+
+## Canonical examples in the repo
+
+The post `apps/blog-app/src/content/2026-06-14-interactive-charts-analogjs-markdown/` is the
+living reference and contains three patterns to copy from:
+- `demo.data.ts` — reusing the shared `BarChartComponent` (data only).
+- `kv-slider.component.ts` — a bespoke single-output slider (signals + computed).
+- `mount-flow.component.ts` — a bespoke step-through diagram (clickable stepper, Play/Prev/Next,
+  interval cleaned up in `ngOnDestroy`).
+
+Shared engine: `src/app/blog/charts/` (`bar-chart.component.ts`, `chart.types.ts`,
+`mount-charts.ts`). The route that mounts: `src/app/routes/blog/[slug].ts`.
+
+## Verify before finishing
+
+1. Production build: `npx nx build blog-app` must exit 0 and the post must prerender to
+   `.vercel/output/static/blog/<slug>/index.html`.
+2. Browser check (Chrome MCP): serve `npx nx serve blog-app`, open
+   `http://localhost:<port>/blog/<slug>` (reload with cache ignored), confirm each widget
+   mounts, is interactive, AND that content **after** every widget still renders (catches the
+   inline-tag truncation gotcha).
+
+See `references/component-templates.md` for copy-paste skeletons.

--- a/.claude/skills/interactive-blog-content/references/component-templates.md
+++ b/.claude/skills/interactive-blog-content/references/component-templates.md
@@ -1,0 +1,148 @@
+# Component templates
+
+Copy-paste skeletons for interactive blog widgets. Adapt names and contents; keep the
+ShadowDom encapsulation and the dark "figure card" palette. Place every file in the post's
+co-located folder: `apps/blog-app/src/content/<slug>/`.
+
+Relative import paths below assume that folder depth (`../../app/blog/...`).
+
+## 1. Placeholder (in the `.md`)
+
+```html
+<div data-chart="my-key">Short fallback caption for no-JS readers. Enable JavaScript to view.</div>
+```
+
+The `data-chart` value is the key looked up in `charts.ts`. Use as many as needed per post.
+
+## 2. Manifest — `charts.ts`
+
+```ts
+// Auto-discovered by mount-charts.ts via import.meta.glob('/src/content/*/charts.ts').
+import { BarChartComponent } from '../../app/blog/charts/bar-chart.component'
+import { ChartManifest } from '../../app/blog/charts/mount-charts'
+import { myBarsConfig } from './my-bars.data'
+import { MyWidgetComponent } from './my-widget.component'
+
+const manifest: ChartManifest = {
+  'my-bars': { component: BarChartComponent, inputs: { config: myBarsConfig } },
+  'my-key': { component: MyWidgetComponent },
+}
+
+export default manifest
+```
+
+## 3. Bar chart data — `*.data.ts` (reusing the shared BarChartComponent)
+
+`BarChartConfig` / `BarMetric` live in `src/app/blog/charts/chart.types.ts`. Each metric is
+either `series` (grouped) OR `single` + `colors`. With more than one metric, a toggle appears.
+
+```ts
+import { BarChartConfig } from '../../app/blog/charts/chart.types'
+
+// Single-series (simplest):
+export const myBarsConfig: BarChartConfig = {
+  labels: ['Analog', 'Next.js', 'SvelteKit'],
+  legend: [{ name: 'Median render (ms)', color: '#7c9cff' }],
+  metrics: [
+    {
+      key: 'render',
+      buttonLabel: 'Median render (ms)',
+      single: [12, 24, 18],
+      colors: ['#7c9cff', '#ff8a5c', '#5ad19a'],
+      note: 'Illustrative median render time (ms) — lower is faster. <b>Hover a bar.</b>',
+      valLabel: (v) => String(v),
+      yLabel: (v) => String(v),
+      tip: (v) => v + ' ms',
+    },
+  ],
+}
+
+// Grouped series (two bars per label) — replace the metric above with:
+//   series: [
+//     { name: 'MLX', color: '#7c9cff', vals: [80, 77, 70] },
+//     { name: 'Ollama', color: '#ff8a5c', vals: [52, 52, 48] },
+//   ],
+// and omit single/colors. Add a second metric object to get a toggle.
+```
+
+## 4. Bespoke component skeleton — `my-widget.component.ts`
+
+Standalone, ShadowDom, signal-based. Self-styled with the dark palette. Clean up any timers
+in `ngOnDestroy`.
+
+```ts
+import { Component, computed, signal, ViewEncapsulation } from '@angular/core'
+
+@Component({
+  selector: 'blog-my-widget',
+  standalone: true,
+  encapsulation: ViewEncapsulation.ShadowDom,
+  template: `
+    <div class="card">
+      <div class="header">
+        <span class="title">Widget title</span>
+        <span class="subtitle">context</span>
+      </div>
+
+      <div class="row">
+        <span class="muted">Input</span>
+        <input type="range" min="0" max="100" [value]="value()"
+               (input)="value.set(+$any($event.target).value)" />
+        <span class="readout">{{ value() }}</span>
+      </div>
+
+      <div class="bar-track"><div class="bar-fill" [style.width.%]="value()"></div></div>
+      <p class="note">Derived output: <b>{{ derived() }}</b></p>
+    </div>
+  `,
+  styles: [
+    `
+      :host { display: block; text-align: left; color: #e6edf3;
+        font: 16px/1.6 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+      .card { background: #161b22; border: 1px solid #30363d; border-radius: 14px;
+        padding: 20px; margin: 22px 0; display: grid; gap: 16px; }
+      .header { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+      .title { font-size: 15px; font-weight: 700; }
+      .subtitle, .muted { color: #9aa7b5; font-size: 13px; }
+      .row { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
+      input[type='range'] { flex: 1; min-width: 200px; accent-color: #7c9cff; height: 5px; }
+      .readout { font-weight: 700; font-variant-numeric: tabular-nums; color: #7c9cff; }
+      .bar-track { background: #0b0f16; border: 1px solid #30363d; border-radius: 8px;
+        height: 24px; overflow: hidden; }
+      .bar-fill { height: 100%; border-radius: 7px; background: #7c9cff;
+        transition: width 0.18s ease; min-width: 3px; }
+      .note { margin: 0; color: #9aa7b5; font-size: 13px; }
+      .note b { color: #e6edf3; }
+    `,
+  ],
+})
+export class MyWidgetComponent {
+  readonly value = signal(40)
+  readonly derived = computed(() => this.value() * 2)
+}
+```
+
+### If the component uses a timer or listener
+
+```ts
+import { Component, OnDestroy, signal, ViewEncapsulation } from '@angular/core'
+
+export class MyWidgetComponent implements OnDestroy {
+  private timer: ReturnType<typeof setInterval> | null = null
+  // ... start with setInterval(...) on some action ...
+  private stop() { if (this.timer) clearInterval(this.timer); this.timer = null }
+  ngOnDestroy() { this.stop() }
+}
+```
+
+## Palette reference
+
+| Token | Value | Use |
+|---|---|---|
+| Card bg | `#161b22` | widget background |
+| Darker bg | `#0b0f16` | tracks, code, toggles |
+| Border | `#30363d` | all borders |
+| Accent | `#7c9cff` | primary highlight / slider |
+| Text | `#e6edf3` | primary text |
+| Muted | `#9aa7b5` | secondary text, captions |
+| Series alt | `#ff8a5c`, `#5ad19a`, `#ffd166`, `#ef6f8c` | extra bar/series colors |


### PR DESCRIPTION
## What

Adds a reusable project skill so future posts get interactive elements "for free", and points the `blog-post-manager` agent at it.

### New skill: `interactive-blog-content`
`.claude/skills/interactive-blog-content/`
- **SKILL.md** — the placeholder + co-located `charts.ts` manifest + `import.meta.glob` auto-discovery + dynamic-mount architecture; when to use; the two paths (reuse `BarChartComponent` vs bespoke component); the verification steps; and the gotchas that have actually bitten this repo (escape raw tags as `&lt;`/`&gt;` in inline code or the post truncates; `ViewEncapsulation.ShadowDom` + dark palette; SSR-safety; clean up timers in `ngOnDestroy`).
- **references/component-templates.md** — copy-paste skeletons: placeholder, `charts.ts` manifest, `BarChartConfig` data (single + grouped), a ShadowDom signal-based widget, timer-cleanup pattern, and the palette table.

### Agent update: `blog-post-manager`
New "Interactive Content" section instructing the agent to **invoke `interactive-blog-content`** whenever a post needs charts/sliders/diagrams/widgets, instead of hand-rolling a mount mechanism or inline `<script>`.

## Why

The interactive-charts architecture (PRs #159–#162) was tribal knowledge. This captures it as a skill the agent will reach for automatically on the next interactive post.

## Notes
- Documentation/config only — no app code, no effect on the Vercel build.
- The canonical living example referenced by the skill is the `2026-06-14-interactive-charts-analogjs-markdown` post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)