### PR TITLE
docs(portfolio): highlight AI & Agents work in biography

### DIFF
--- a/libs/portfolio/home/feature/src/lib/biography/biography.component.html
+++ b/libs/portfolio/home/feature/src/lib/biography/biography.component.html
@@ -66,7 +66,8 @@
         <div class="mx-auto max-w-prose text-base lg:max-w-none">
           <p class="text-lg text-gray-500">
             I have done researching and creating my first IT blog since 2012 then starting to design websites and web
-            applications, and I am passionate about the web development career.
+            applications, and I am passionate about the web development career as well as designing AI agents and
+            agentic systems.
           </p>
         </div>
         <div class="prose prose-indigo mx-auto mt-5 text-gray-500 lg:col-start-1 lg:row-start-1 lg:max-w-none">
@@ -74,10 +75,18 @@
             I am a full stack developer. I take projects from the initial concept stage through to completion. I stay on
             top of leading front and back end technologies such as
             <strong
-              >Angular, NodeJS, GCP, SQL/NoSQL, LAMP Stack (Linux, Apache, MySQL and PHP), HTML 5 and CSS 3, Docker,
-              Restful API</strong
+              >Angular, NodeJS, GCP, SQL/NoSQL, Docker, Restful API, AI/LLMs, MCP, LangGraph and Claude Agent
+              SDK</strong
             >
             to ensure the optimum code performance and site security for my clients.
+          </p>
+          <p>
+            A big part of my work is building <strong>AI and agentic systems</strong>. I design and build
+            production AI agents that automate engineering workflows — automated code review, issue triage and code
+            implementation — and ship customer-facing AI features powered by the
+            <strong>Model Context Protocol (MCP)</strong>. I work across the agentic stack with tools such as
+            <strong>LangGraph, LangSmith and the Claude API</strong>, building provider-agnostic integrations and the
+            observability and quality gates that keep agents reliable in production.
           </p>
           <p>
             My favorite work environments are <strong>Angular, NodeJS and GCP</strong>. They are outstanding digital


### PR DESCRIPTION
## Summary
Updates the Biography section on the home page to reflect AI & Agents work.

- Adds a dedicated paragraph on building **AI and agentic systems** (production AI agents for code review, issue triage, and code implementation; customer-facing MCP features; LangGraph / LangSmith / Claude API; provider-agnostic integrations + observability/quality gates).
- Refreshes the bolded tech stack: adds **AI/LLMs, MCP, LangGraph, Claude Agent SDK**; removes **LAMP Stack, HTML 5, CSS 3**.
- Frames AI work as established (not a recent pivot).
- **Employer-agnostic** — no company name, internal project codenames, metrics, or other internal details.

## Verification
Previewed locally via `nx serve portfolio` at `/#about` — renders correctly on desktop viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated portfolio biography section with expanded information on web development expertise and specialized knowledge in AI agents and agentic systems design
  * Refreshed technology stack highlights, replacing prior items with modern AI and LLM-related tools including Claude Agent SDK, LangGraph, and MCP

<!-- end of auto-generated comment: release notes by coderabbit.ai -->