### PR TITLE
feat: dark-first redesign with light toggle, viz, and accessibility

### DIFF
--- a/apps/blog-app/index.html
+++ b/apps/blog-app/index.html
@@ -5,7 +5,22 @@
     <title>Dale Nguyen's Blog</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="theme-color" content="#0a0b10" />
     <link rel="icon" type="image/x-icon" href="/src/favicon.ico" />
+
+    <!-- Apply the saved theme before first paint to avoid a flash. Dark is the
+         default (no class); only an explicit `light` choice adds the class. -->
+    <script>
+      ;(function () {
+        try {
+          if (localStorage.getItem('theme') === 'light') {
+            document.documentElement.classList.add('light')
+          }
+        } catch (e) {}
+      })()
+    </script>
+
     <link rel="stylesheet" href="/src/styles.css" />
 
     <!-- Logichat — loaded on first user interaction to keep its SDK off the critical path -->

--- a/apps/blog-app/src/app/blog/charts/bar-chart.component.ts
+++ b/apps/blog-app/src/app/blog/charts/bar-chart.component.ts
@@ -78,12 +78,12 @@ const H = 340
       :host {
         display: block;
         text-align: left;
-        color: #e6edf3;
+        color: var(--chart-fg, #e6edf3);
         font: 16px/1.6 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
       }
       .card {
-        background: #161b22;
-        border: 1px solid #30363d;
+        background: var(--chart-card, #161b22);
+        border: 1px solid var(--chart-border, #30363d);
         border-radius: 14px;
         padding: 20px;
         margin: 22px 0;
@@ -101,7 +101,7 @@ const H = 340
         gap: 16px;
         flex-wrap: wrap;
         font-size: 13px;
-        color: #9aa7b5;
+        color: var(--chart-muted, #9aa7b5);
       }
       .legend span {
         display: inline-flex;
@@ -116,15 +116,15 @@ const H = 340
       }
       .toggle {
         display: inline-flex;
-        background: #0b0f16;
-        border: 1px solid #30363d;
+        background: var(--chart-toggle, #0b0f16);
+        border: 1px solid var(--chart-border, #30363d);
         border-radius: 10px;
         padding: 3px;
       }
       .toggle button {
         background: none;
         border: none;
-        color: #9aa7b5;
+        color: var(--chart-muted, #9aa7b5);
         padding: 6px 13px;
         border-radius: 8px;
         cursor: pointer;
@@ -143,18 +143,18 @@ const H = 340
         overflow: visible;
       }
       .axis-line {
-        stroke: #30363d;
+        stroke: var(--chart-border, #30363d);
       }
       .axis-text {
-        fill: #6e7b8a;
+        fill: var(--chart-axis, #6e7b8a);
         font-size: 12px;
       }
       .glab {
-        fill: #9aa7b5;
+        fill: var(--chart-muted, #9aa7b5);
         font-size: 12.5px;
       }
       .vlab {
-        fill: #e6edf3;
+        fill: var(--chart-fg, #e6edf3);
         font-size: 11.5px;
         font-weight: 600;
       }
@@ -169,27 +169,28 @@ const H = 340
         opacity: 0.82;
       }
       .note {
-        color: #9aa7b5;
+        color: var(--chart-muted, #9aa7b5);
         font-size: 13.5px;
         margin: 8px 0 0;
       }
       .note b {
-        color: #e6edf3;
+        color: var(--chart-fg, #e6edf3);
       }
       .tip {
         position: fixed;
         pointer-events: none;
-        background: rgba(0, 0, 0, 0.88);
-        border: 1px solid #30363d;
+        background: var(--chart-card, #161b22);
+        box-shadow: 0 6px 20px rgb(0 0 0 / 0.3);
+        border: 1px solid var(--chart-border, #30363d);
         border-radius: 9px;
         padding: 8px 11px;
         font-size: 12.5px;
-        color: #e6edf3;
+        color: var(--chart-fg, #e6edf3);
         z-index: 50;
         max-width: 240px;
       }
       .tip b {
-        color: #fff;
+        color: var(--chart-fg, #e6edf3);
       }
     `,
   ],

--- a/apps/blog-app/src/app/blog/models.ts
+++ b/apps/blog-app/src/app/blog/models.ts
@@ -8,4 +8,5 @@ export interface PostAttributes {
   profileImage: string
   author: string
   series?: string
+  draft?: boolean
 }

--- a/apps/blog-app/src/app/blog/models.ts
+++ b/apps/blog-app/src/app/blog/models.ts
@@ -6,9 +6,6 @@ export interface PostAttributes {
   categories: string[]
   published: string
   profileImage: string
-  author: {
-    firstName: string
-    lastName: string
-  }
+  author: string
   series?: string
 }

--- a/apps/blog-app/src/app/routes/[...page-not-found].ts
+++ b/apps/blog-app/src/app/routes/[...page-not-found].ts
@@ -1,5 +1,6 @@
 import { RouteMeta } from '@analogjs/router'
 import { Component } from '@angular/core'
+import { RouterLink } from '@angular/router'
 
 export const routeMeta: RouteMeta = {
   title: `Dale Nguyen Blog - Page not found`,
@@ -8,45 +9,36 @@ export const routeMeta: RouteMeta = {
 
 @Component({
   standalone: true,
+  imports: [RouterLink],
   template: `
-    <div class="flex min-h-full flex-col bg-white pt-16 pb-12">
+    <div class="flex min-h-full flex-col bg-bg pt-16 pb-12">
       <main class="mx-auto flex w-full max-w-7xl flex-grow flex-col justify-center px-6 lg:px-8">
         <div class="flex flex-shrink-0 justify-center">
-          <a href="/" class="inline-flex">
-            <span class="sr-only">Your Company</span>
-            <img class="h-12 w-auto" src="https://tailwindui.com/img/logos/mark.svg?color=indigo&shade=600" alt="" />
+          <a routerLink="/" class="inline-flex">
+            <span class="sr-only">Dale Nguyen — home</span>
+            <img class="h-12 w-12 rounded-full ring-1 ring-border" src="/assets/images/dale-nguyen-avatar.webp" alt="Dale Nguyen" />
           </a>
         </div>
-        <div class="py-16">
-          <div class="text-center">
-            <p class="text-base font-semibold text-indigo-600">404</p>
-            <h1 class="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">Page not found.</h1>
-            <p class="mt-2 text-base text-gray-500">Sorry, we couldn’t find the page you’re looking for.</p>
-            <div class="mt-6">
-              <a href="#" class="text-base font-medium text-indigo-600 hover:text-indigo-500">
-                Go back home
-                <span aria-hidden="true"> &rarr;</span>
-              </a>
-            </div>
+        <div class="py-16 text-center">
+          <p class="text-base font-semibold text-accent">404</p>
+          <h1 class="mt-2 text-4xl font-bold tracking-tight text-fg sm:text-5xl">Page not found.</h1>
+          <p class="mt-4 text-base text-fg-muted">Sorry, we couldn’t find the page you’re looking for.</p>
+          <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
+            <a
+              routerLink="/"
+              class="rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 hover:shadow-glow focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Go back home
+            </a>
+            <a
+              routerLink="/blog"
+              class="rounded-lg border border-border bg-surface px-5 py-2.5 text-sm font-semibold text-fg transition hover:bg-surface-2 hover:border-accent"
+            >
+              Read the blog <span aria-hidden="true">→</span>
+            </a>
           </div>
         </div>
       </main>
-      <footer class="mx-auto w-full max-w-7xl flex-shrink-0 px-6 lg:px-8">
-        <nav class="flex justify-center space-x-4">
-          <a
-            href="https://twitter.com/dale_nguyen"
-            target="_blank"
-            class="flex items-center gap-0.5 text-sm font-medium text-gray-500 hover:text-gray-600"
-          >
-            <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
-              <path
-                d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"
-              />
-            </svg>
-            Twitter</a
-          >
-        </nav>
-      </footer>
     </div>
   `,
 })

--- a/apps/blog-app/src/app/routes/blog/[slug].ts
+++ b/apps/blog-app/src/app/routes/blog/[slug].ts
@@ -19,6 +19,7 @@ import {
 } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { RouterLink } from '@angular/router'
+import { readingTimes } from 'virtual:reading-time-manifest'
 import { PostAttributes } from '../../blog/models'
 import { postMetaResolver, postTitleResolver } from '../../blog/resolvers'
 
@@ -31,11 +32,11 @@ export const routeMeta: RouteMeta = {
   standalone: true,
   imports: [CommonModule, MarkdownComponent, RouterLink],
   template: `
-      <div class="relative px-6 lg:px-8">
+      <div class="relative mx-auto max-w-3xl px-6 lg:px-8">
         <nav class="flex py-4" aria-label="Breadcrumb">
           <ol class="inline-flex items-center space-x-1 md:space-x-3">
             <li class="inline-flex items-center">
-              <a routerLink="/" class="inline-flex items-center text-sm font-medium text-gray-700 hover:text-blue-600">
+              <a routerLink="/" class="inline-flex items-center text-sm font-medium text-fg-muted hover:text-accent transition-colors">
                 <svg class="w-3 h-3 mr-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
                   <path d="m19.707 9.293-2-2-7-7a1 1 0 0 0-1.414 0l-7 7-2 2a1 1 0 0 0 1.414 1.414L2 10.414V18a2 2 0 0 0 2 2h3a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h3a2 2 0 0 0 2-2v-7.586l.293.293a1 1 0 0 0 1.414-1.414Z"/>
                 </svg>
@@ -44,18 +45,18 @@ export const routeMeta: RouteMeta = {
             </li>
             <li>
               <div class="flex items-center">
-                <svg class="w-3 h-3 text-gray-400 mx-1" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
+                <svg class="w-3 h-3 text-fg-muted mx-1" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
                   <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>
                 </svg>
-                <a routerLink="/blog" class="ml-1 text-sm font-medium text-gray-700 hover:text-blue-600 md:ml-2">Blog</a>
+                <a routerLink="/blog" class="ml-1 text-sm font-medium text-fg-muted hover:text-accent md:ml-2 transition-colors">Blog</a>
               </div>
             </li>
             <li aria-current="page" *ngIf="post()as post">
               <div class="flex items-center">
-                <svg class="w-3 h-3 text-gray-400 mx-1" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
+                <svg class="w-3 h-3 text-fg-muted mx-1" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
                   <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 9 4-4-4-4"/>
                 </svg>
-                <span class="ml-1 text-sm font-medium text-gray-500 md:ml-2 truncate whitespace-nowrap overflow-hidden max-w-[120px] sm:max-w-[180px] md:max-w-[240px]">{{ post.attributes.title }}</span>
+                <span class="ml-1 text-sm font-medium text-fg md:ml-2 truncate whitespace-nowrap overflow-hidden max-w-[120px] sm:max-w-[180px] md:max-w-[240px]">{{ post.attributes.title }}</span>
               </div>
             </li>
           </ol>
@@ -66,7 +67,7 @@ export const routeMeta: RouteMeta = {
 
             <!-- Feature image display (LCP). Serve a WebP variant when the cover
                  is a local PNG; the PNG stays the fallback and the og:image. -->
-            <div class="mb-8 rounded-lg overflow-hidden shadow-lg">
+            <div class="mb-8 rounded-2xl overflow-hidden shadow-lg ring-1 ring-border">
               <picture>
                 @if (coverWebp()) {
                   <source type="image/webp" [srcset]="coverWebp()" />
@@ -81,12 +82,12 @@ export const routeMeta: RouteMeta = {
               </picture>
             </div>
 
-            <h1>{{ post.attributes.title }}</h1>
+            <h1 class="text-fg">{{ post.attributes.title }}</h1>
 
             <!-- Categories display -->
             <div class="flex flex-wrap justify-center gap-2 mb-6">
               @for (category of post.attributes.categories; track category) {
-                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800">
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-600/15 text-accent ring-1 ring-border">
                   {{ category | titlecase }}
                 </span>
               }
@@ -97,38 +98,46 @@ export const routeMeta: RouteMeta = {
               <div class="flex items-center">
                 <img
                   [src]="post.attributes.profileImage"
-                  [alt]="'Photo of ' + post.attributes.author.firstName"
-                  class="w-10 h-10 rounded-full border-2 border-gray-200 mr-3"
+                  [alt]="'Photo of ' + post.attributes.author"
+                  class="w-10 h-10 rounded-full ring-2 ring-border mr-3"
                 />
                 <div class="text-left">
-                  <div class="font-medium text-gray-900">
-                    {{ post.attributes.author.firstName }} {{ post.attributes.author.lastName }}
+                  <div class="font-medium text-fg">
+                    {{ post.attributes.author }}
                   </div>
-                  <div class="text-sm text-gray-500 flex items-center">
-                    <span class="mr-1">
+                  <div class="text-sm text-fg-muted flex items-center gap-3">
+                    <span class="inline-flex items-center gap-1">
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                       </svg>
+                      <time [attr.datetime]="post.attributes.published">
+                        {{ post.attributes.published | date: 'longDate' }}
+                      </time>
                     </span>
-                    <time [attr.datetime]="post.attributes.published">
-                      {{ post.attributes.published | date: 'longDate' }}
-                    </time>
+                    @if (readingMinutes(); as mins) {
+                      <span class="inline-flex items-center gap-1">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        {{ mins }} min read
+                      </span>
+                    }
                   </div>
                 </div>
               </div>
             </div>
 
             @if (series()) {
-            <div class="text-center mb-8 border rounded-lg p-4">
-              <h3 class="text-xl font-bold text-gray-700 mb-2">{{ series()!.name }} ({{ series()!.count }} Part Series)</h3>
+            <div class="text-center mb-8 border border-border rounded-xl bg-surface p-4">
+              <h3 class="text-xl font-bold text-fg mb-2">{{ series()!.name }} ({{ series()!.count }} Part Series)</h3>
               <div class="text-left mx-auto max-w-md text-base">
                 @for (post of series()!.posts; track post.slug; let i = $index) {
                   <div class="my-2">
-                      <span class="mr-2 font-medium bg-indigo-100 text-indigo-800 px-2 py-1 rounded-full">{{ i + 1 }}</span>
+                      <span class="mr-2 font-medium bg-indigo-600/15 text-accent px-2 py-1 rounded-full">{{ i + 1 }}</span>
                       @if (post.isCurrent) {
-                        <span class="font-semibold text-indigo-700">{{ post.displayTitle }}</span>
+                        <span class="font-semibold text-accent">{{ post.displayTitle }}</span>
                       } @else {
-                        <a [routerLink]="['/blog', post.slug]" class="text-indigo-600 hover:text-indigo-800 hover:underline">
+                        <a [routerLink]="['/blog', post.slug]" class="text-accent hover:underline underline-offset-2">
                           <span>{{ post.displayTitle }}</span>
                         </a>
                       }
@@ -160,6 +169,9 @@ export default class BlogPostComponent implements AfterViewInit, OnDestroy {
   private chartRefs: ComponentRef<unknown>[] = []
   private giscusObserver?: IntersectionObserver
   readonly post = toSignal(injectContent<PostAttributes>())
+
+  // Estimated reading time (minutes) from the build-time manifest.
+  readonly readingMinutes = computed(() => readingTimes[this.post()?.attributes.slug ?? ''] ?? 0)
 
   // WebP srcset for the cover image, but only for local blog PNGs (which have a
   // generated .webp sibling). External covers (e.g. ButterCMS) and covers that
@@ -266,7 +278,7 @@ export default class BlogPostComponent implements AfterViewInit, OnDestroy {
       const btn = doc.createElement('button')
       btn.textContent = 'Copy'
       btn.style.cssText =
-        'position:absolute;top:0.5rem;right:0.5rem;padding:0.2rem 0.5rem;font-size:0.75rem;background:#e0e0e0;border:none;border-radius:3px;cursor:pointer;opacity:0.7'
+        'position:absolute;top:0.5rem;right:0.5rem;padding:0.25rem 0.6rem;font-size:0.75rem;background:rgb(var(--surface-2));color:rgb(var(--fg-muted));border:1px solid rgb(var(--border));border-radius:6px;cursor:pointer;opacity:0.85'
       btn.addEventListener('click', () => {
         const code = pre.querySelector('code')?.innerText ?? pre.innerText
         navigator.clipboard.writeText(code).then(() => {

--- a/apps/blog-app/src/app/routes/blog/index.ts
+++ b/apps/blog-app/src/app/routes/blog/index.ts
@@ -1,141 +1,229 @@
 import { injectContentFiles } from '@analogjs/content'
 import { RouteMeta } from '@analogjs/router'
-import { CommonModule } from '@angular/common'
-import { Component } from '@angular/core'
+import { DatePipe, TitleCasePipe } from '@angular/common'
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core'
 import { RouterLink } from '@angular/router'
+import { RevealDirective } from '@dalenguyen/portfolio/shell/ui'
+import { readingTimes } from 'virtual:reading-time-manifest'
 import { PostAttributes } from '../../blog/models'
 
 export const routeMeta: RouteMeta = {
   title: `Dale Nguyen Blog`,
   meta: [{ name: 'description', content: 'Dale Nguyen Blog Posts' }],
 }
+
+interface YearBar {
+  year: string
+  count: number
+  pct: number
+}
+
 @Component({
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe, TitleCasePipe, RouterLink, RevealDirective],
   template: `
-    <div class="bg-gradient-to-b from-gray-50 to-white py-16 px-4 sm:px-6 lg:px-8">
+    <div class="bg-bg py-16 px-4 sm:px-6 lg:px-8">
       <div class="mx-auto max-w-7xl">
-        <!-- Header Section -->
-        <div class="text-center mb-16">
-          <h1 class="text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl md:text-6xl">
-            <span class="block">Insights & Ideas</span>
-            <span class="block text-indigo-600 mt-2">From the Blog</span>
+        <!-- Header -->
+        <div class="text-center mb-12">
+          <h1 class="text-4xl font-bold tracking-tight text-fg sm:text-5xl md:text-6xl">
+            Insights &amp; Ideas
+            <span class="mt-2 block bg-gradient-to-r from-accent to-cyan-400 bg-clip-text text-transparent">
+              From the Blog
+            </span>
           </h1>
-          <p class="mt-4 max-w-2xl mx-auto text-xl text-gray-500">
+          <p class="mt-4 max-w-2xl mx-auto text-lg text-fg-muted">
             Welcome to my collection of thoughts, ideas, and discoveries. Hope you find something inspiring!
           </p>
         </div>
 
-        <!-- Featured Article (First Article) -->
-        @if (posts.length) {
-        <div class="mb-16">
-          @for (post of posts; track post.attributes.slug; let i = $index) { @if (i === 0) {
-          <div
-            class="relative rounded-xl overflow-hidden shadow-2xl transition-all duration-300 hover:shadow-indigo-100"
-          >
-            <!-- Darker overlay with increased opacity for better contrast with white text -->
-            <div
-              class="absolute inset-0 bg-gradient-to-t from-gray-900 via-gray-800/80 to-gray-900/60 opacity-90"
-            ></div>
-            <!-- Darkened and blurred image for better text readability -->
-            <img
-              [src]="post.attributes.coverImage"
-              [alt]="post.attributes.title"
-              class="w-full h-[500px] object-cover filter blur-[2px] brightness-[0.7] contrast-[1.1]"
-            />
-            <!-- Content container with enhanced text visibility -->
-            <div class="absolute bottom-0 left-0 right-0 p-8">
-              <div class="flex flex-wrap items-center gap-2 mb-4">
-                @for (category of post.attributes.categories; track category) {
-                <span
-                  class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-600 text-white"
-                >
-                  {{ category | titlecase }}
-                </span>
-                }
-                <span class="text-sm text-white font-medium">{{ post.attributes.published | date: 'mediumDate' }}</span>
-              </div>
-              <h2 class="text-3xl font-bold mb-3 text-white drop-shadow-sm">{{ post.attributes.title }}</h2>
-              <p class="text-lg mb-6 text-white font-medium drop-shadow-sm">{{ post.attributes.description }}</p>
-              <div class="flex items-center">
-                <img
-                  [src]="post.attributes.profileImage"
-                  [alt]="'Photo of ' + post.attributes.author.firstName"
-                  class="h-10 w-10 rounded-full mr-3 border-2 border-white"
-                />
-                <div>
-                  <p class="font-medium text-white">{{ post.attributes.author }}</p>
-                </div>
-                <a
-                  routerLink="/blog/{{ post.attributes.slug }}"
-                  class="ml-auto bg-white text-indigo-700 px-6 py-2 rounded-lg font-medium hover:bg-indigo-50 transition-colors focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 focus:outline-none cursor-pointer"
-                >
-                  Read Article
-                </a>
-              </div>
-            </div>
+        <!-- Posts-per-year visualization -->
+        <div class="mx-auto mb-12 max-w-2xl rounded-2xl border border-border bg-surface p-6">
+          <div class="mb-5 flex items-baseline justify-between">
+            <h2 class="text-sm font-semibold uppercase tracking-wider text-fg-muted">Posts by year</h2>
+            <span class="text-sm text-fg-muted">{{ allPosts.length }} posts total</span>
           </div>
-          } }
+          <div class="flex items-end gap-2 sm:gap-4">
+            @for (y of postsByYear; track y.year) {
+              <div class="flex flex-1 flex-col items-center">
+                <span class="mb-1 text-xs font-semibold text-fg">{{ y.count }}</span>
+                <div class="flex h-28 w-full items-end">
+                  <div
+                    class="w-full rounded-t-md bg-gradient-to-t from-accent-fill to-accent transition-[height] duration-500"
+                    [style.height.%]="y.pct"
+                    [title]="y.count + ' posts in ' + y.year"
+                  ></div>
+                </div>
+                <span class="mt-2 text-xs text-fg-muted">{{ y.year }}</span>
+              </div>
+            }
+          </div>
         </div>
+
+        <!-- Category filters -->
+        <div class="mb-12 flex flex-wrap justify-center gap-2">
+          <button type="button" [class]="chipClass(null)" (click)="select(null)">
+            All <span class="opacity-70">{{ allPosts.length }}</span>
+          </button>
+          @for (c of categories; track c.name) {
+            <button type="button" [class]="chipClass(c.name)" (click)="select(c.name)">
+              {{ c.name | titlecase }} <span class="opacity-70">{{ c.count }}</span>
+            </button>
+          }
+        </div>
+
+        <!-- Featured Article -->
+        @if (featured(); as post) {
+          <div class="mb-14">
+            <article class="group relative overflow-hidden rounded-3xl border border-border bg-surface shadow-xl transition-shadow duration-300 hover:shadow-glow">
+              <div class="relative h-[360px] sm:h-[440px]">
+                <img
+                  [src]="post.attributes.coverImage"
+                  [alt]="post.attributes.title"
+                  class="h-full w-full object-cover brightness-[0.55]"
+                />
+                <div class="absolute inset-0 bg-gradient-to-t from-black/90 via-black/45 to-transparent"></div>
+                <div class="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
+                  <div class="mb-3 flex flex-wrap items-center gap-2">
+                    @for (category of post.attributes.categories; track category) {
+                      <span class="inline-flex items-center rounded-full bg-indigo-600 px-3 py-1 text-xs font-medium text-white">
+                        {{ category | titlecase }}
+                      </span>
+                    }
+                    <span class="text-sm font-medium text-white/90">{{ post.attributes.published | date: 'mediumDate' }}</span>
+                    @if (readingTime(post.attributes.slug); as mins) {
+                      <span class="text-sm text-white/70">· {{ mins }} min read</span>
+                    }
+                  </div>
+                  <h2 class="mb-3 text-2xl font-bold text-white sm:text-3xl">{{ post.attributes.title }}</h2>
+                  <p class="mb-5 max-w-3xl text-base text-white/85 line-clamp-2 sm:text-lg">{{ post.attributes.description }}</p>
+                  <div class="flex items-center gap-3">
+                    <img [src]="post.attributes.profileImage" [alt]="post.attributes.author" class="h-9 w-9 rounded-full ring-2 ring-white/30" />
+                    <span class="text-sm font-medium text-white">{{ post.attributes.author }}</span>
+                    <a
+                      routerLink="/blog/{{ post.attributes.slug }}"
+                      class="ml-auto rounded-lg bg-white px-5 py-2 text-sm font-semibold text-gray-900 transition hover:bg-white/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                    >
+                      Read Article
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </article>
+          </div>
         }
 
         <!-- Article Grid -->
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          @for (post of posts; track post.attributes.slug; let i = $index) { @if (i !== 0) {
-          <div
-            class="bg-white rounded-lg overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 flex flex-col"
-          >
-            <div class="relative h-48 overflow-hidden">
-              <img
-                [src]="post.attributes.coverImage"
-                alt=""
-                class="w-full h-full object-cover transform hover:scale-105 transition-transform duration-500"
-              />
-              <div class="absolute top-0 right-0 mt-4">
-                @for (category of post.attributes.categories; track category) {
-                <span
-                  class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 mr-2"
-                >
-                  {{ category | titlecase }}
-                </span>
-                }
-              </div>
-            </div>
-            <div class="p-6 flex-grow">
-              <div class="flex items-center text-sm text-gray-500 mb-2">
-                <time [attr.datetime]="post.attributes.published">{{
-                  post.attributes.published | date: 'mediumDate'
-                }}</time>
-              </div>
-              <a routerLink="/blog/{{ post.attributes.slug }}" class="block cursor-pointer">
-                <h3 class="text-xl font-bold text-gray-900 mb-3 hover:text-indigo-600 transition-colors">
-                  {{ post.attributes.title }}
-                </h3>
-                <p class="text-gray-600 mb-4 line-clamp-3">{{ post.attributes.description }}</p>
-              </a>
-            </div>
-            <div class="px-6 pb-6 pt-2 border-t border-gray-100 mt-auto">
-              <div class="flex items-center">
-                <img [src]="post.attributes.profileImage" alt="" class="h-8 w-8 rounded-full" />
-                <span class="ml-2 text-sm font-medium text-gray-700">{{ post.attributes.author }}</span>
-
-                <a
-                  routerLink="/blog/{{ post.attributes.slug }}"
-                  class="ml-auto text-indigo-600 hover:text-indigo-800 text-sm font-medium transition-colors cursor-pointer"
-                >
-                  Read More →
-                </a>
-              </div>
-            </div>
+        @if (rest().length) {
+          <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+            @for (post of rest(); track post.attributes.slug) {
+              <article
+                dalReveal
+                class="group relative flex flex-col overflow-hidden rounded-2xl border border-border bg-surface transition duration-300 hover:-translate-y-1 hover:border-accent hover:shadow-glow"
+              >
+                <div class="relative h-48 overflow-hidden">
+                  <img
+                    [src]="post.attributes.coverImage"
+                    alt=""
+                    loading="lazy"
+                    class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+                  />
+                  @if (post.attributes.categories.length) {
+                    <div class="absolute right-3 top-3 flex flex-wrap justify-end gap-1.5">
+                      @for (category of post.attributes.categories.slice(0, 2); track category) {
+                        <span class="inline-flex items-center rounded-full bg-bg/70 px-2.5 py-0.5 text-xs font-medium text-fg ring-1 ring-border backdrop-blur">
+                          {{ category | titlecase }}
+                        </span>
+                      }
+                    </div>
+                  }
+                </div>
+                <div class="flex flex-grow flex-col p-6">
+                  <div class="mb-2 flex items-center gap-2 text-sm text-fg-muted">
+                    <time [attr.datetime]="post.attributes.published">{{ post.attributes.published | date: 'mediumDate' }}</time>
+                    @if (readingTime(post.attributes.slug); as mins) {
+                      <span aria-hidden="true">·</span>
+                      <span>{{ mins }} min read</span>
+                    }
+                  </div>
+                  <h3 class="mb-3 text-xl font-bold text-fg transition-colors group-hover:text-accent">
+                    <a routerLink="/blog/{{ post.attributes.slug }}" class="after:absolute after:inset-0">
+                      {{ post.attributes.title }}
+                    </a>
+                  </h3>
+                  <p class="mb-4 line-clamp-3 text-fg-muted">{{ post.attributes.description }}</p>
+                  <div class="mt-auto flex items-center border-t border-border pt-4">
+                    <img [src]="post.attributes.profileImage" alt="" class="h-8 w-8 rounded-full ring-1 ring-border" />
+                    <span class="ml-2 text-sm font-medium text-fg-muted">{{ post.attributes.author }}</span>
+                    <span class="ml-auto text-sm font-medium text-accent">Read More →</span>
+                  </div>
+                </div>
+              </article>
+            }
           </div>
-          } }
-        </div>
+        } @else if (!featured()) {
+          <p class="text-center text-fg-muted">No posts in this category yet.</p>
+        }
       </div>
     </div>
   `,
 })
 export default class BlogComponent {
-  readonly posts = injectContentFiles<PostAttributes>((contentFile) =>
+  readonly allPosts = injectContentFiles<PostAttributes>((contentFile) =>
     contentFile.filename.includes('/src/content'),
   ).sort((a, b) => b.attributes.published.localeCompare(a.attributes.published))
+
+  readonly selectedCategory = signal<string | null>(null)
+
+  readonly filteredPosts = computed(() => {
+    const cat = this.selectedCategory()
+    if (!cat) return this.allPosts
+    return this.allPosts.filter((p) => p.attributes.categories?.includes(cat))
+  })
+
+  readonly featured = computed(() => this.filteredPosts()[0] ?? null)
+  readonly rest = computed(() => this.filteredPosts().slice(1))
+
+  // Top categories by post count for the filter chips.
+  readonly categories = (() => {
+    const counts = new Map<string, number>()
+    for (const post of this.allPosts) {
+      for (const category of post.attributes.categories ?? []) {
+        counts.set(category, (counts.get(category) ?? 0) + 1)
+      }
+    }
+    return [...counts.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+      .slice(0, 12)
+  })()
+
+  // Posts grouped by publication year, oldest to newest, scaled to the busiest year.
+  readonly postsByYear: YearBar[] = (() => {
+    const counts = new Map<string, number>()
+    for (const post of this.allPosts) {
+      const year = post.attributes.published.slice(0, 4)
+      counts.set(year, (counts.get(year) ?? 0) + 1)
+    }
+    const max = Math.max(1, ...counts.values())
+    return [...counts.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([year, count]) => ({ year, count, pct: Math.round((count / max) * 100) }))
+  })()
+
+  readingTime(slug: string): number {
+    return readingTimes[slug] ?? 0
+  }
+
+  select(category: string | null): void {
+    this.selectedCategory.set(category)
+  }
+
+  chipClass(name: string | null): string {
+    const base = 'rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors cursor-pointer'
+    return this.selectedCategory() === name
+      ? `${base} border-transparent bg-indigo-600 text-white`
+      : `${base} border-border text-fg-muted hover:bg-surface-2 hover:text-fg`
+  }
 }

--- a/apps/blog-app/src/app/routes/blog/index.ts
+++ b/apps/blog-app/src/app/routes/blog/index.ts
@@ -63,11 +63,11 @@ interface YearBar {
 
         <!-- Category filters -->
         <div class="mb-12 flex flex-wrap justify-center gap-2">
-          <button type="button" [class]="chipClass(null)" (click)="select(null)">
+          <button type="button" [class]="chipClass(null)" [attr.aria-pressed]="selectedCategory() === null" (click)="select(null)">
             All <span class="opacity-70">{{ allPosts.length }}</span>
           </button>
           @for (c of categories; track c.name) {
-            <button type="button" [class]="chipClass(c.name)" (click)="select(c.name)">
+            <button type="button" [class]="chipClass(c.name)" [attr.aria-pressed]="selectedCategory() === c.name" (click)="select(c.name)">
               {{ c.name | titlecase }} <span class="opacity-70">{{ c.count }}</span>
             </button>
           }
@@ -170,8 +170,8 @@ interface YearBar {
   `,
 })
 export default class BlogComponent {
-  readonly allPosts = injectContentFiles<PostAttributes>((contentFile) =>
-    contentFile.filename.includes('/src/content'),
+  readonly allPosts = injectContentFiles<PostAttributes>(
+    (contentFile) => contentFile.filename.includes('/src/content') && !contentFile.attributes.draft,
   ).sort((a, b) => b.attributes.published.localeCompare(a.attributes.published))
 
   readonly selectedCategory = signal<string | null>(null)

--- a/apps/blog-app/src/app/routes/bucket-list.ts
+++ b/apps/blog-app/src/app/routes/bucket-list.ts
@@ -19,89 +19,91 @@ interface BucketListItem {
   standalone: true,
   imports: [CommonModule, FormsModule],
   template: `
-    <div class="min-h-screen bg-gradient-to-b from-blue-50 to-white py-12 px-4 sm:px-6 lg:px-8">
-      <header class="text-center mb-12">
-        <h1 class="text-4xl font-extrabold text-gray-900 mb-3">100 Things To Do Before I Leave This Earth</h1>
-        <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+    <div class="min-h-screen bg-bg py-12 px-4 sm:px-6 lg:px-8">
+      <header class="text-center mb-10">
+        <h1 class="text-4xl font-bold tracking-tight text-fg mb-3 sm:text-5xl">
+          100 Things To Do Before I Leave This Earth
+        </h1>
+        <p class="text-lg text-fg-muted max-w-3xl mx-auto">
           My personal bucket list of experiences, adventures, and achievements
         </p>
       </header>
 
       <div class="max-w-5xl mx-auto">
-        <div class="bg-white rounded-xl shadow-xl overflow-hidden mb-8">
-          <div class="p-6 bg-gradient-to-r from-blue-500 to-indigo-600">
-            <div class="flex justify-between items-center">
-              <h2 class="text-2xl font-bold text-white">My Bucket List</h2>
-              <div class="text-white">
-                <span class="font-medium">{{ completedCount() }}</span> of
-                <span class="font-medium">{{ totalCount() }}</span> completed
-              </div>
+        <!-- Progress visualization -->
+        <div class="rounded-2xl border border-border bg-surface p-6 mb-8">
+          <div class="flex items-center justify-between mb-3">
+            <h2 class="text-lg font-semibold text-fg">My Progress</h2>
+            <div class="text-fg-muted">
+              <span class="font-semibold text-fg">{{ completedCount() }}</span> of
+              <span class="font-semibold text-fg">{{ totalCount() }}</span> completed
             </div>
           </div>
+          <div class="h-3 w-full overflow-hidden rounded-full bg-surface-2" role="progressbar" [attr.aria-valuenow]="completionPct()" aria-valuemin="0" aria-valuemax="100">
+            <div
+              class="h-full rounded-full bg-gradient-to-r from-accent-fill to-accent transition-[width] duration-700"
+              [style.width.%]="completionPct()"
+            ></div>
+          </div>
+          <p class="mt-2 text-sm text-fg-muted">{{ completionPct() }}% complete</p>
+        </div>
 
-          <div class="p-6">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              <div
-                *ngFor="let item of sortedBucketListItems(); let i = index"
-                class="transform transition-all duration-300 hover:scale-105"
-              >
-                <div
-                  class="border rounded-lg overflow-hidden shadow-sm h-full flex flex-col"
-                  [ngClass]="{
-                    'bg-green-50 border-green-200': item.completed,
-                    'bg-white border-gray-200': !item.completed
-                  }"
-                >
-                  <div class="p-4 flex items-start gap-3 flex-grow">
-                    <div class="flex-shrink-0 pt-1">
-                      <input
-                        type="checkbox"
-                        [id]="'item-' + i"
-                        [checked]="item.completed"
-                        (change)="toggleComplete(item)"
-                        class="h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 cursor-pointer"
-                      />
-                    </div>
-                    <label
-                      [for]="'item-' + i"
-                      class="cursor-pointer flex-grow"
-                      [ngClass]="{ 'line-through text-gray-500': item.completed, 'text-gray-800': !item.completed }"
-                    >
-                      <div class="font-medium mb-1">
-                        <span class="mr-1">{{ i + 1 }}.</span>
-                        <a
-                          *ngIf="item.link"
-                          [href]="item.link"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          class="hover:text-blue-600 hover:underline inline items-center"
-                          (click)="$event.stopPropagation()"
-                        >
-                          {{ item.text }}
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-4 w-4 ml-1 inline"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                            />
-                          </svg>
-                        </a>
-                        <span *ngIf="!item.link">{{ item.text }}</span>
-                      </div>
-                    </label>
-                  </div>
-                  <div *ngIf="item.completed" class="bg-green-100 px-4 py-2 text-green-800 text-sm font-medium">
-                    Completed! 🎉
-                  </div>
-                </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div
+            *ngFor="let item of sortedBucketListItems(); let i = index"
+            class="h-full flex flex-col overflow-hidden rounded-xl border transition duration-300 hover:-translate-y-0.5"
+            [ngClass]="{
+              'border-accent/40 bg-accent-fill/10': item.completed,
+              'border-border bg-surface hover:border-accent': !item.completed
+            }"
+          >
+            <div class="p-4 flex items-start gap-3 flex-grow">
+              <div class="flex-shrink-0 pt-1">
+                <input
+                  type="checkbox"
+                  [id]="'item-' + i"
+                  [checked]="item.completed"
+                  (change)="toggleComplete(item)"
+                  class="h-5 w-5 rounded border-border bg-surface-2 accent-indigo-600 focus:ring-2 focus:ring-accent cursor-pointer"
+                />
               </div>
+              <label
+                [for]="'item-' + i"
+                class="cursor-pointer flex-grow"
+                [ngClass]="{ 'line-through text-fg-muted': item.completed, 'text-fg': !item.completed }"
+              >
+                <div class="font-medium mb-1">
+                  <span class="mr-1">{{ i + 1 }}.</span>
+                  <a
+                    *ngIf="item.link"
+                    [href]="item.link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-accent hover:underline underline-offset-2 inline items-center"
+                    (click)="$event.stopPropagation()"
+                  >
+                    {{ item.text }}
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="h-4 w-4 ml-1 inline"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                      />
+                    </svg>
+                  </a>
+                  <span *ngIf="!item.link">{{ item.text }}</span>
+                </div>
+              </label>
+            </div>
+            <div *ngIf="item.completed" class="border-t border-accent/20 px-4 py-2 text-sm font-medium text-accent">
+              Completed! 🎉
             </div>
           </div>
         </div>
@@ -129,6 +131,11 @@ export default class BucketListComponent implements OnInit {
 
   totalCount = computed(() => {
     return this.bucketListItems().length
+  })
+
+  completionPct = computed(() => {
+    const total = this.totalCount()
+    return total ? Math.round((this.completedCount() / total) * 100) : 0
   })
 
   ngOnInit(): void {

--- a/apps/blog-app/src/app/routes/index.ts
+++ b/apps/blog-app/src/app/routes/index.ts
@@ -5,6 +5,11 @@ export const routeMeta: RouteMeta = {
   title: 'Home | Dale Nguyen',
 
   meta: [
+    {
+      name: 'description',
+      content:
+        'Dale Nguyen — a Toronto-based software engineer and digital architect building for the web and the agentic era, from Angular and GCP to production AI agents and the Model Context Protocol.',
+    },
     { name: 'og:title', content: 'Home | Dale Nguyen' },
     {
       name: 'og:description',

--- a/apps/blog-app/src/app/routes/learn/index.ts
+++ b/apps/blog-app/src/app/routes/learn/index.ts
@@ -10,13 +10,11 @@ export const routeMeta: RouteMeta = {
 @Component({
   standalone: true,
   template: `
-    <div class="bg-gradient-to-b from-gray-50 to-white py-16 px-4 sm:px-6 lg:px-8">
+    <div class="bg-bg py-16 px-4 sm:px-6 lg:px-8">
       <div class="mx-auto max-w-7xl">
-        <div class="text-center mb-16">
-          <h1 class="text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl">
-            <span class="block">Learning Resources</span>
-          </h1>
-          <p class="mt-4 max-w-2xl mx-auto text-xl text-gray-500">
+        <div class="text-center mb-12">
+          <h1 class="text-4xl font-bold tracking-tight text-fg sm:text-5xl">Learning Resources</h1>
+          <p class="mt-4 max-w-2xl mx-auto text-lg text-fg-muted">
             Standalone interactive pages for exploring ideas and concepts.
           </p>
         </div>
@@ -25,18 +23,18 @@ export const routeMeta: RouteMeta = {
           @for (page of pages; track page.url) {
             <a
               [href]="page.url"
-              class="bg-white rounded-lg overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 flex flex-col p-6 cursor-pointer no-underline"
+              class="group relative flex flex-col rounded-2xl border border-border bg-surface p-6 no-underline transition duration-300 hover:-translate-y-1 hover:border-accent hover:shadow-glow"
             >
               @if (page.date) {
-                <p class="text-xs text-gray-400 mb-2">{{ page.date }}</p>
+                <p class="mb-2 text-xs font-medium text-fg-muted">{{ page.date }}</p>
               }
-              <h3 class="text-xl font-bold text-gray-900 mb-3 hover:text-indigo-600 transition-colors">
+              <h3 class="mb-3 text-xl font-bold text-fg transition-colors group-hover:text-accent">
                 {{ page.title }}
               </h3>
               @if (page.description) {
-                <p class="text-gray-600 line-clamp-3">{{ page.description }}</p>
+                <p class="line-clamp-3 text-fg-muted">{{ page.description }}</p>
               }
-              <span class="mt-auto pt-4 text-indigo-600 text-sm font-medium">Open →</span>
+              <span class="mt-auto pt-4 text-sm font-medium text-accent">Open →</span>
             </a>
           }
         </div>

--- a/apps/blog-app/src/content/2026-06-06-local-ai-coding-agents.md
+++ b/apps/blog-app/src/content/2026-06-06-local-ai-coding-agents.md
@@ -157,7 +157,7 @@ print(json.dumps({'models': [m]}, indent=2))
 " > ~/.codex/model_catalog.json
 ```
 
-The two critical fields are `supported_reasoning_levels: []` and `supports_reasoning_summaries: false`. Without them, Codex sends a `thinking` parameter that Ollama rejects with `does not support thinking`. Note that `qwen3-coder:30b` does support chain-of-thought reasoning — Qwen3 models reason internally via `<think>` tags. Disabling this API parameter just stops Codex from requesting it in an OpenAI-specific format that Ollama doesn't accept.
+The two critical fields are `supported_reasoning_levels: []` and `supports_reasoning_summaries: false`. Without them, Codex sends a `thinking` parameter that Ollama rejects with `does not support thinking`. Note that `qwen3-coder:30b` does support chain-of-thought reasoning — Qwen3 models reason internally via `&lt;think&gt;` tags. Disabling this API parameter just stops Codex from requesting it in an OpenAI-specific format that Ollama doesn't accept.
 
 Verify the catalog loaded correctly:
 

--- a/apps/blog-app/src/content/2026-06-14-all-green-lighthouse-analogjs-blog.md
+++ b/apps/blog-app/src/content/2026-06-14-all-green-lighthouse-analogjs-blog.md
@@ -296,7 +296,7 @@ providers: [provideZonelessChangeDetection() /* … */]
 
 This is safe only if the app is signal- and event-driven: any view that refreshes from a bare `setTimeout`, `addEventListener`, or RxJS `subscribe` (rather than a signal or a template `(event)`) will silently stop updating under zoneless — audit for those first. While I was at it I also moved `@angular/material` off the critical path (the header icons became inline SVG, dropping the Material Icons web font) and lazy-loaded `@sentry/browser`. Net effect: **eager JS for the post fell from 658 KB to 583 KB, mobile Total Blocking Time dropped to ~20 ms, and mobile Performance went 66 → 77.**
 
-**WebP cover images — the LCP follow-up.** With the framework cost gone, the largest remaining mobile cost was the cover image (the LCP element), shipped as a PNG. I generated a WebP variant for every local cover and serve it through a `<picture>`, keeping the PNG as both the `<img>` fallback and the `og:image`:
+**WebP cover images — the LCP follow-up.** With the framework cost gone, the largest remaining mobile cost was the cover image (the LCP element), shipped as a PNG. I generated a WebP variant for every local cover and serve it through a `&lt;picture&gt;`, keeping the PNG as both the `&lt;img&gt;` fallback and the `og:image`:
 
 ```html
 <picture>
@@ -307,7 +307,7 @@ This is safe only if the app is signal- and event-driven: any view that refreshe
 </picture>
 ```
 
-The WebP source is **root-relative** on purpose: a `<source>` does not fall back to the `<img>` on a 404, so an absolute prod URL would break the hero on preview builds. Across 25 covers this cut **12.2 MB → 0.9 MB (~92%)** — the interactive-charts cover went 92 KB → 36 KB — taking mobile LCP from 5.8 s to ~4.8 s and Performance to **78**.
+The WebP source is **root-relative** on purpose: a `&lt;source&gt;` does not fall back to the `&lt;img&gt;` on a 404, so an absolute prod URL would break the hero on preview builds. Across 25 covers this cut **12.2 MB → 0.9 MB (~92%)** — the interactive-charts cover went 92 KB → 36 KB — taking mobile LCP from 5.8 s to ~4.8 s and Performance to **78**.
 
 **Inline the CSS + preload the LCP image — the step that actually broke the ceiling.** Mobile was stuck in the high-70s with LCP ~4.8 s. I assumed I'd need classic *critical-CSS extraction* (inline above-the-fold, async the rest). Measuring first saved the effort: the entire stylesheet is only **~9 KB brotli**, already Tailwind-purged. So extraction was pointless — the cost wasn't bytes, it was the extra **render-blocking request** (a full round-trip on Slow 4G) plus discovering the cover image late. Two small `postRenderingHooks` fixed both:
 
@@ -351,7 +351,7 @@ Eight failing audits across four Lighthouse categories, now zero. The fixes in r
 5. **Add `/llms.txt`** — Agentic Browsing 33 → 100.
 6. **Lazy-load Giscus + `fetchpriority` on LCP image** — zero third-party scripts on initial load, LCP stays green.
 7. **Zoneless change detection + trim the eager bundle** (drop `zone.js`, inline-SVG icons instead of Angular Material, lazy Sentry) — mobile Performance 66 → 77, eager JS 658 → 583 KB, TBT ~20 ms.
-8. **WebP cover images via `<picture>`** — covers 92% smaller (12.2 MB → 0.9 MB), mobile 77 → 78, LCP 5.8 s → ~4.8 s.
+8. **WebP cover images via `&lt;picture&gt;`** — covers 92% smaller (12.2 MB → 0.9 MB), mobile 77 → 78, LCP 5.8 s → ~4.8 s.
 9. **Inline the global CSS + preload the LCP image** — FCP 2.1 s → 0.9 s, LCP 4.8 s → 1.2 s, mobile Performance 78 → **100**.
 
 The audit fixes were small and surgical; going zoneless was the biggest single TBT win; but the real surprise was the last step — **mobile 78 → 100 from inlining a 9 KB stylesheet and preloading one image**. The recurring lesson: *measure before reaching for the heavy tool.* Scroll-gated deferral failed because audit tools auto-scroll; critical-CSS extraction was unnecessary because the CSS was tiny. The page that started at 90/77/92/33 desktop now sits at a perfect **100/100/100/100 on both desktop and mobile**.

--- a/apps/blog-app/src/plugins/reading-time-manifest.plugin.ts
+++ b/apps/blog-app/src/plugins/reading-time-manifest.plugin.ts
@@ -1,0 +1,63 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Plugin } from 'vite'
+
+const VIRTUAL_ID = 'virtual:reading-time-manifest'
+const RESOLVED_ID = '\0' + VIRTUAL_ID
+const WORDS_PER_MINUTE = 200
+
+// Resolve a post's slug the same way the prerenderer does: frontmatter `slug`
+// if present, otherwise the filename without extension.
+function slugFor(file: string, raw: string): string {
+  const frontmatter = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] ?? ''
+  const slug = frontmatter
+    .match(/^slug:\s*(.+)$/m)?.[1]
+    ?.trim()
+    .replace(/^['"]|['"]$/g, '')
+  return slug || file.replace(/\.md$/, '')
+}
+
+// A deliberately rough estimate: strip frontmatter and fenced code, drop HTML
+// tags and markdown punctuation, then count words at 200 wpm (min 1).
+function readingMinutes(raw: string): number {
+  const body = raw
+    .replace(/^---\r?\n[\s\S]*?\r?\n---/, '')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#>*_`~[\]()!]/g, ' ')
+  const words = body.split(/\s+/).filter(Boolean).length
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE))
+}
+
+function scan(contentDir: string): Record<string, number> {
+  let files: string[]
+  try {
+    files = readdirSync(contentDir).filter((f) => f.endsWith('.md'))
+  } catch {
+    return {}
+  }
+  const map: Record<string, number> = {}
+  for (const file of files) {
+    const raw = readFileSync(join(contentDir, file), 'utf-8')
+    map[slugFor(file, raw)] = readingMinutes(raw)
+  }
+  return map
+}
+
+/**
+ * Exposes `virtual:reading-time-manifest` — a `{ [slug]: minutes }` map built at
+ * build time from the markdown sources. Keeps post bodies out of the blog-list
+ * bundle (the list only needs the number, not the content).
+ */
+export function readingTimeManifestPlugin(contentDir: string): Plugin {
+  return {
+    name: 'reading-time-manifest',
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_ID
+    },
+    load(id) {
+      if (id !== RESOLVED_ID) return
+      return `export const readingTimes = ${JSON.stringify(scan(contentDir))};`
+    },
+  }
+}

--- a/apps/blog-app/src/reading-time-manifest.d.ts
+++ b/apps/blog-app/src/reading-time-manifest.d.ts
@@ -1,0 +1,4 @@
+declare module 'virtual:reading-time-manifest' {
+  /** Map of post slug to estimated reading time in minutes. */
+  export const readingTimes: Record<string, number>
+}

--- a/apps/blog-app/src/styles.css
+++ b/apps/blog-app/src/styles.css
@@ -240,7 +240,7 @@ main a:not([class]) {
     padding: 0.2rem 0.4rem;
     border-radius: 4px;
     font-size: 0.95rem;
-    font-family: 'SFMono-Regular', ui-monospace, 'Courier New', Courier, monospace;
+    font-family: SFMono-Regular, ui-monospace, 'Courier New', Courier, monospace;
   }
 
   /* Code blocks */

--- a/apps/blog-app/src/styles.css
+++ b/apps/blog-app/src/styles.css
@@ -6,10 +6,100 @@
 @import 'prismjs/plugins/diff-highlight/prism-diff-highlight.css';
 @import 'prismjs/plugins/toolbar/prism-toolbar.css';
 
+/* ============================================================================
+   Design tokens — dark is the default (:root); .light overrides on <html>.
+   Channels are space-separated RGB so Tailwind's `rgb(var(--x) / <alpha>)`
+   mapping (see tailwind.config.cjs) supports opacity utilities.
+   Every text/background pairing below is chosen to meet WCAG AA (>=4.5:1 for
+   body text, >=3:1 for large text) in both themes.
+   ========================================================================= */
+:root {
+  /* surfaces */
+  --bg: 10 11 16; /* #0a0b10 page */
+  --surface: 20 22 29; /* #14161d cards */
+  --surface-2: 28 31 42; /* #1c1f2a elevated / insets */
+  --border: 38 43 54; /* #262b36 */
+
+  /* text */
+  --fg: 230 237 243; /* #e6edf3 ~14:1 on bg */
+  --fg-muted: 154 167 181; /* #9aa7b5 ~7:1 on bg */
+
+  /* accent */
+  --accent: 129 140 248; /* #818cf8 indigo-400 — links/text, ~6:1 on bg */
+  --accent-fill: 94 106 210; /* #5e6ad2 — fills/glow (matches learn pages) */
+  --accent-fg: 8 17 31; /* #08111f — text on accent fill */
+
+  /* code (GitHub-dark inspired, verified on --code-bg) */
+  --code-bg: 22 27 34; /* #161b22 */
+  --code-fg: 230 237 243; /* #e6edf3 */
+  --code-border: 48 54 61; /* #30363d */
+  --tok-comment: 139 148 158; /* #8b949e */
+  --tok-punct: 201 209 217; /* #c9d1d9 */
+  --tok-keyword: 255 123 114; /* #ff7b72 */
+  --tok-string: 126 231 135; /* #7ee787 */
+  --tok-function: 210 168 255; /* #d2a8ff */
+  --tok-number: 121 192 255; /* #79c0ff */
+  --tok-class: 255 166 87; /* #ffa657 */
+
+  /* In-post chart widget (ShadowDom). Custom properties inherit through the
+     shadow boundary, so the chart re-themes from these. Hex (no alpha needed). */
+  --chart-card: #161b22;
+  --chart-border: #30363d;
+  --chart-fg: #e6edf3;
+  --chart-muted: #9aa7b5;
+  --chart-axis: #6e7b8a;
+  --chart-toggle: #0b0f16;
+
+  color-scheme: dark;
+}
+
+.light {
+  --bg: 255 255 255;
+  --surface: 255 255 255;
+  --surface-2: 249 250 251; /* #f9fafb */
+  --border: 229 231 235; /* #e5e7eb */
+
+  --fg: 17 24 39; /* #111827 */
+  --fg-muted: 75 85 99; /* #4b5563 ~7:1 on white */
+
+  --accent: 79 70 229; /* #4f46e5 indigo-600 — AA on white */
+  --accent-fill: 79 70 229;
+  --accent-fg: 255 255 255;
+
+  /* code — high-contrast palette tuned for the light #f6f8fa background */
+  --code-bg: 246 248 250; /* #f6f8fa */
+  --code-fg: 31 35 40; /* #1f2328 */
+  --code-border: 224 224 224; /* #e0e0e0 */
+  --tok-comment: 87 96 106; /* #57606a */
+  --tok-punct: 36 41 47; /* #24292f */
+  --tok-keyword: 207 34 46; /* #cf222e */
+  --tok-string: 10 110 49; /* #0a6e31 */
+  --tok-function: 102 57 186; /* #6639ba */
+  --tok-number: 5 80 174; /* #0550ae */
+  --tok-class: 149 56 0; /* #953800 */
+
+  /* In-post chart widget — light variant */
+  --chart-card: #ffffff;
+  --chart-border: #e5e7eb;
+  --chart-fg: #111827;
+  --chart-muted: #4b5563;
+  --chart-axis: #6b7280;
+  --chart-toggle: #f3f4f6;
+
+  color-scheme: light;
+}
+
 html,
 body {
   height: 100%;
   scroll-behavior: smooth;
+}
+
+body {
+  background-color: rgb(var(--bg));
+  color: rgb(var(--fg));
+  /* Smooth theme switch, but never animate the page on first paint. */
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 /* Ensure the app container takes full height */
@@ -29,12 +119,14 @@ h1 {
   font-size: 2rem;
   font-weight: 600;
   margin-bottom: 1rem;
+  letter-spacing: -0.02em;
 }
 
 h2 {
   font-size: 1.5rem;
   font-weight: 500;
   margin: 1rem 0;
+  letter-spacing: -0.01em;
 }
 
 h3 {
@@ -55,8 +147,61 @@ img:not([width]):not([height]) {
   aspect-ratio: 16 / 9;
 }
 
+/* Themed selection + accent-tinted scrollbar */
+::selection {
+  background: rgb(var(--accent-fill) / 0.35);
+  color: rgb(var(--fg));
+}
+
+/* Unclassed links inside content (e.g. markdown routes like /about, /contact)
+   get the accent treatment. Classed links (nav, buttons) keep their own styles. */
+main a:not([class]) {
+  color: rgb(var(--accent));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* ============================================================================
+   Scroll-reveal — progressive enhancement. SSR/no-JS renders fully visible;
+   the [dalReveal] directive adds `.reveal` (browser-only) to opt elements into
+   the hidden->visible transition, then `.is-visible` when they enter view.
+   ========================================================================= */
+.reveal {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.6s cubic-bezier(0.22, 1, 0.36, 1), transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
+}
+.reveal.is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html,
+  body {
+    scroll-behavior: auto;
+  }
+  .reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+
+/* ============================================================================
+   Markdown article content
+   ========================================================================= */
 .analog-markdown {
   text-align: left;
+  color: rgb(var(--fg));
 
   p {
     padding: 1rem 0;
@@ -65,11 +210,16 @@ img:not([width]):not([height]) {
   /* Ensure images in markdown content maintain aspect ratio */
   img {
     display: block;
+    border-radius: 0.5rem;
   }
 
   a {
     text-decoration: underline;
-    color: #4632de;
+    text-underline-offset: 2px;
+    color: rgb(var(--accent));
+  }
+  a:hover {
+    text-decoration-thickness: 2px;
   }
 
   ul {
@@ -85,36 +235,35 @@ img:not([width]):not([height]) {
 
   /* Inline code */
   code {
-    background-color: #f5f5f5;
+    background-color: rgb(var(--code-bg));
+    color: rgb(var(--code-fg));
     padding: 0.2rem 0.4rem;
-    border-radius: 3px;
-    font-size: 1rem;
-    font-family: 'Courier New', Courier, monospace;
+    border-radius: 4px;
+    font-size: 0.95rem;
+    font-family: 'SFMono-Regular', ui-monospace, 'Courier New', Courier, monospace;
   }
 
   /* Code blocks */
   pre {
     display: block;
-    background-color: #f5f5f5;
+    background-color: rgb(var(--code-bg));
     padding: 1rem;
-    border-radius: 5px;
+    border-radius: 10px;
     overflow-x: auto;
     margin: 1rem 0;
-    border: 1px solid #e0e0e0;
+    border: 1px solid rgb(var(--code-border));
   }
 
   pre code {
     background-color: transparent;
     padding: 0;
     border-radius: 0;
-    font-size: 1rem;
+    font-size: 0.95rem;
     line-height: 1.6;
   }
 
   /* Responsive tables: scroll horizontally within their own box on narrow
-     viewports instead of overflowing the article and breaking mobile layout.
-     Font is dialed down from the article's text-lg so the data reads as a
-     table rather than oversized body copy. */
+     viewports instead of overflowing the article and breaking mobile layout. */
   table {
     display: block;
     width: max-content;
@@ -126,19 +275,25 @@ img:not([width]):not([height]) {
     line-height: 1.4;
   }
 
-  th, td {
-    border: 1px solid #e0e0e0;
+  th,
+  td {
+    border: 1px solid rgb(var(--border));
     padding: 0.5rem 0.75rem;
     text-align: left;
   }
 
   th {
-    background-color: #f5f5f5;
+    background-color: rgb(var(--surface-2));
     font-weight: 600;
   }
 
   tr:nth-child(even) {
-    background-color: #fafafa;
+    background-color: rgb(var(--surface) / 0.5);
+  }
+
+  strong {
+    color: rgb(var(--fg));
+    font-weight: 600;
   }
 }
 
@@ -147,37 +302,37 @@ figure {
   text-align: center;
   figcaption {
     font-size: 0.8rem;
-    color: #666;
+    color: rgb(var(--fg-muted));
   }
 }
 
 blockquote {
-  background-color: #f0f0f0;
+  background-color: rgb(var(--surface-2));
+  color: rgb(var(--fg));
   padding: 1rem;
-  border-left: 4px solid #4632de;
+  border-left: 4px solid rgb(var(--accent-fill));
+  border-radius: 0 8px 8px 0;
 }
 
-/*
- * High-contrast Prism syntax palette.
- * The default prism.css theme renders many tokens (comments, punctuation,
- * keywords, functions, numbers) below the WCAG AA 4.5:1 ratio on the light
- * #f5f5f5 code background, failing Lighthouse's color-contrast audit. Every
- * color below is verified >= 4.5:1 against that background. Placed after the
- * prism @import so these win on equal specificity.
- */
+/* ============================================================================
+   Prism syntax highlighting — theme-aware via the --tok-* tokens above, so
+   both dark and light meet WCAG AA against their respective code backgrounds.
+   Placed after the prism @import so these win on equal specificity.
+   ========================================================================= */
 code[class*='language-'],
 pre[class*='language-'] {
-  color: #1f2328;
+  color: rgb(var(--code-fg));
   text-shadow: none;
+  background: none;
 }
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #57606a;
+  color: rgb(var(--tok-comment));
 }
 .token.punctuation {
-  color: #24292f;
+  color: rgb(var(--tok-punct));
 }
 .token.property,
 .token.tag,
@@ -186,7 +341,7 @@ pre[class*='language-'] {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: #0550ae;
+  color: rgb(var(--tok-number));
 }
 .token.selector,
 .token.attr-name,
@@ -194,27 +349,27 @@ pre[class*='language-'] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #0a6e31;
+  color: rgb(var(--tok-string));
 }
 .token.operator,
 .token.entity,
 .token.url,
 .language-css .token.string,
 .style .token.string {
-  color: #953800;
+  color: rgb(var(--tok-keyword));
   background: none;
 }
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-  color: #cf222e;
+  color: rgb(var(--tok-keyword));
 }
 .token.function,
 .token.class-name {
-  color: #6639ba;
+  color: rgb(var(--tok-function));
 }
 .token.regex,
 .token.important,
 .token.variable {
-  color: #953800;
+  color: rgb(var(--tok-class));
 }

--- a/apps/blog-app/tailwind.config.cjs
+++ b/apps/blog-app/tailwind.config.cjs
@@ -1,11 +1,53 @@
 const { createGlobPatternsForDependencies } = require('@nx/angular/tailwind')
 const { join } = require('path')
+const plugin = require('tailwindcss/plugin')
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'), ...createGlobPatternsForDependencies(__dirname)],
   theme: {
-    extend: {},
+    extend: {
+      // Semantic, theme-aware colors backed by CSS variables (see styles.css).
+      // RGB channel triplets + <alpha-value> so opacity utilities (bg-surface/70)
+      // keep working. Added via `extend` so the default Tailwind palette stays
+      // available during the migration.
+      colors: {
+        bg: 'rgb(var(--bg) / <alpha-value>)',
+        surface: 'rgb(var(--surface) / <alpha-value>)',
+        'surface-2': 'rgb(var(--surface-2) / <alpha-value>)',
+        border: 'rgb(var(--border) / <alpha-value>)',
+        fg: 'rgb(var(--fg) / <alpha-value>)',
+        'fg-muted': 'rgb(var(--fg-muted) / <alpha-value>)',
+        accent: 'rgb(var(--accent) / <alpha-value>)',
+        'accent-fill': 'rgb(var(--accent-fill) / <alpha-value>)',
+        'accent-fg': 'rgb(var(--accent-fg) / <alpha-value>)',
+      },
+      boxShadow: {
+        glow: '0 0 0 1px rgb(var(--accent-fill) / 0.35), 0 8px 30px -8px rgb(var(--accent-fill) / 0.45)',
+      },
+      keyframes: {
+        'fade-up': {
+          '0%': { opacity: '0', transform: 'translateY(14px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        'gradient-pan': {
+          '0%, 100%': { 'background-position': '0% 50%' },
+          '50%': { 'background-position': '100% 50%' },
+        },
+      },
+      animation: {
+        'fade-up': 'fade-up 0.6s cubic-bezier(0.22, 1, 0.36, 1) both',
+        'gradient-pan': 'gradient-pan 12s ease infinite',
+      },
+    },
   },
-  plugins: [require('@tailwindcss/typography'), require('@tailwindcss/aspect-ratio')],
+  plugins: [
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/aspect-ratio'),
+    // `light:` variant for the rare case a token can't express the difference
+    // (e.g. shadows that should only appear in light mode).
+    plugin(function ({ addVariant }) {
+      addVariant('light', '.light &')
+    }),
+  ],
 }

--- a/apps/blog-app/vite.config.ts
+++ b/apps/blog-app/vite.config.ts
@@ -7,8 +7,10 @@ import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { defineConfig } from 'vite'
 import { learnManifestPlugin } from './src/plugins/learn-manifest.plugin'
+import { readingTimeManifestPlugin } from './src/plugins/reading-time-manifest.plugin'
 
 const learnDir = join(__dirname, '../../libs/portfolio/shared/learn')
+const contentDir = join(__dirname, 'src/content')
 
 // Candidate roots that hold the built client assets at prerender time.
 const clientAssetDirs = [
@@ -193,6 +195,7 @@ export default defineConfig(({ mode }) => {
         },
       }),
       learnManifestPlugin(learnDir),
+      readingTimeManifestPlugin(contentDir),
       nxViteTsPaths(),
     ],
     test: {

--- a/docs/plans/2026-06-14-dark-mode-redesign-design.md
+++ b/docs/plans/2026-06-14-dark-mode-redesign-design.md
@@ -1,0 +1,68 @@
+# Dark-first modern redesign — dalenguyen.me
+
+Date: 2026-06-14
+Branch: `feat/dark-mode-redesign`
+
+## Goal
+
+Redesign the whole site (AnalogJS app at `apps/blog-app` + shared `libs/portfolio`)
+with a modern, minimal aesthetic, motion/data visualization, and full responsiveness.
+**Dark mode is the default**, with a light toggle. All text must meet WCAG AA contrast
+in both themes.
+
+## Decisions (confirmed with user)
+
+- **Theme:** dark default + light toggle, choice remembered in `localStorage`.
+- **Aesthetic:** modern minimal + accent glow (Vercel/Linear feel). Anchor accent to the
+  existing learn-page indigo `#5e6ad2`.
+- **Viz:** all three — (1) polish & motion, (2) reading data viz, (3) better code/diagrams.
+- **Depth:** full overhaul of every routed surface.
+- **Scope add-ons (approved):** replace Angular Material cards; add reading time +
+  posts/year chart + category filters on `/blog`; contrast pass on standalone learn HTML.
+
+## Theme architecture
+
+Semantic design tokens via CSS variables, switched by a class on `<html>`:
+
+- `styles.css`: `:root { ...dark... }` and `.light { ...overrides... }`.
+- `tailwind.config.cjs`: map semantic colors (`bg`, `surface`, `surface-2`, `border`,
+  `fg`, `fg-muted`, `accent`, `accent-fg`) to the CSS vars.
+- Components use semantic classes (`bg-surface`, `text-fg`, `text-fg-muted`, `border-border`,
+  `text-accent`) → contrast tuned in one place.
+- Default `<html>` = dark (no class). Toggle adds `.light`. Inline script in `index.html`
+  applies the saved theme before first paint (no flash, SSR-safe).
+
+## Color tokens
+
+Dark (default): page `#0a0b10` · surface `#14161d` · elevated `#1c1f2a` · border `#262b36` ·
+text `#e6edf3` · muted `#9aa7b5` · link/accent-text `#818cf8` · accent fill `#5e6ad2` ·
+gradient indigo `#6366f1` → cyan `#22d3ee`.
+
+Light: page `#ffffff` · surface `#ffffff` · border `#e5e7eb` · text `#111827` ·
+muted `#4b5563` · link/accent `#4f46e5`.
+
+## Per-surface plan
+
+- Shell (`app.component.ts`, `footer.component.ts`): glassy sticky header + theme toggle; new footer.
+- Home: intro, publication, portfolio (de-Material), recent-posts, biography, contact.
+- `/blog`: dark cards, featured post, reading time, posts-per-year `BarChartComponent`, category filters.
+- `/blog/[slug]`: dark markdown + Prism, restyled copy buttons, reading time header.
+- `/learn`: dark cards.
+- bucket-list: dark + progress viz.
+- 404: re-theme + remove leftover tailwindui/"Your Company" boilerplate.
+- about.md / contact.md: minor re-theme.
+- Standalone learn HTML: contrast/accent pass only (already dark).
+
+## Motion
+
+Hero gradient glow, scroll-reveal (IntersectionObserver), hover lifts, smooth theme
+transition — all gated behind `prefers-reduced-motion`.
+
+## Out of scope
+
+Resume component (not routed in this app).
+
+## Verification
+
+`nx build blog-app` passes → serve → walk every route in both themes → Lighthouse/axe
+accessibility audit on home + a post → verify token contrast ratios.

--- a/libs/portfolio/home/feature/src/lib/biography/biography.component.html
+++ b/libs/portfolio/home/feature/src/lib/biography/biography.component.html
@@ -1,10 +1,10 @@
-<div class="overflow-hidden bg-white" id="about">
-  <div class="relative mx-auto max-w-7xl py-16 px-6 lg:px-8">
-    <div class="absolute top-0 bottom-0 left-3/4 hidden w-screen bg-gray-50 lg:block"></div>
+<div class="overflow-hidden bg-bg" id="about">
+  <div class="relative mx-auto max-w-7xl py-16 sm:py-20 px-6 lg:px-8">
+    <div class="absolute top-0 bottom-0 left-3/4 hidden w-screen bg-surface/30 lg:block"></div>
     <div class="mx-auto max-w-prose text-base lg:grid lg:max-w-none lg:grid-cols-2 lg:gap-8">
       <div>
-        <h2 class="text-lg font-semibold text-indigo-600">Biography</h2>
-        <h3 class="mt-2 text-3xl font-bold leading-8 tracking-tight text-gray-900 sm:text-4xl">Meet Dale Nguyen</h3>
+        <h2 class="text-sm font-semibold uppercase tracking-wider text-accent">Biography</h2>
+        <h3 class="mt-2 text-3xl font-bold leading-8 tracking-tight text-fg sm:text-4xl">Meet Dale Nguyen</h3>
       </div>
     </div>
     <div class="mt-8 lg:grid lg:grid-cols-2 lg:gap-8">
@@ -26,7 +26,7 @@
               height="20"
               patternUnits="userSpaceOnUse"
             >
-              <rect x="0" y="0" width="4" height="4" class="text-gray-200" fill="currentColor" />
+              <rect x="0" y="0" width="4" height="4" class="text-border" fill="currentColor" />
             </pattern>
           </defs>
           <rect width="404" height="384" fill="url(#de316486-4a29-4312-bdfc-fbce2132a2c1)" />
@@ -35,17 +35,17 @@
           <figure>
             <div class="aspect-w-12 aspect-h-7 lg:aspect-none">
               <img
-                class="rounded-lg object-cover object-center shadow-lg"
+                class="rounded-2xl object-cover object-center shadow-lg ring-1 ring-border"
                 src="assets/images/home/biography.jpg"
                 alt="Dale is Kensington market"
                 width="1184"
                 height="1376"
               />
             </div>
-            <figcaption class="mt-3 flex text-sm text-gray-500">
+            <figcaption class="mt-3 flex text-sm text-fg-muted">
               <!-- Heroicon name: mini/camera -->
               <svg
-                class="h-5 w-5 flex-none text-gray-400"
+                class="h-5 w-5 flex-none text-fg-muted"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
                 fill="currentColor"
@@ -64,34 +64,35 @@
       </div>
       <div class="mt-8 lg:mt-0">
         <div class="mx-auto max-w-prose text-base lg:max-w-none">
-          <p class="text-lg text-gray-500">
+          <p class="text-lg text-fg-muted">
             I have done researching and creating my first IT blog since 2012 then starting to design websites and web
             applications, and I am passionate about the web development career as well as designing AI agents and
             agentic systems.
           </p>
         </div>
-        <div class="prose prose-indigo mx-auto mt-5 text-gray-500 lg:col-start-1 lg:row-start-1 lg:max-w-none">
+        <div class="mx-auto mt-5 space-y-4 text-fg-muted lg:col-start-1 lg:row-start-1 lg:max-w-none">
           <p>
             I am a full stack developer. I take projects from the initial concept stage through to completion. I stay on
             top of leading front and back end technologies such as
-            <strong
+            <strong class="font-semibold text-fg"
               >Angular, NodeJS, GCP, SQL/NoSQL, Docker, Restful API, AI/LLMs, MCP, LangGraph and Claude Agent
               SDK</strong
             >
             to ensure the optimum code performance and site security for my clients.
           </p>
           <p>
-            A big part of my work is building <strong>AI and agentic systems</strong>. I design and build
-            production AI agents that automate engineering workflows — automated code review, issue triage and code
-            implementation — and ship customer-facing AI features powered by the
-            <strong>Model Context Protocol (MCP)</strong>. I work across the agentic stack with tools such as
-            <strong>LangGraph, LangSmith and the Claude API</strong>, building provider-agnostic integrations and the
-            observability and quality gates that keep agents reliable in production.
+            A big part of my work is building <strong class="font-semibold text-fg">AI and agentic systems</strong>. I
+            design and build production AI agents that automate engineering workflows — automated code review, issue
+            triage and code implementation — and ship customer-facing AI features powered by the
+            <strong class="font-semibold text-fg">Model Context Protocol (MCP)</strong>. I work across the agentic stack
+            with tools such as <strong class="font-semibold text-fg">LangGraph, LangSmith and the Claude API</strong>,
+            building provider-agnostic integrations and the observability and quality gates that keep agents reliable in
+            production.
           </p>
           <p>
-            My favorite work environments are <strong>Angular, NodeJS and GCP</strong>. They are outstanding digital
-            technologies because of pre-build flexibility, ease-of-use structure code that allows you to spend more time
-            on creating an actual website instead of spending time on repetitive code.
+            My favorite work environments are <strong class="font-semibold text-fg">Angular, NodeJS and GCP</strong>.
+            They are outstanding digital technologies because of pre-build flexibility, ease-of-use structure code that
+            allows you to spend more time on creating an actual website instead of spending time on repetitive code.
           </p>
           <p>In my spare time, I love to travel as much as possible.</p>
         </div>

--- a/libs/portfolio/home/feature/src/lib/contact/contact.component.ts
+++ b/libs/portfolio/home/feature/src/lib/contact/contact.component.ts
@@ -5,79 +5,43 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
   selector: 'dalenguyen-contact',
   standalone: true,
   template: `
-    <!-- This example requires Tailwind CSS v3.0+ -->
-    <div class="relative bg-gray-900" id="contact">
-      <div class="relative h-80 overflow-hidden bg-indigo-600 md:absolute md:left-0 md:h-full md:w-1/3 lg:w-1/2">
-        <img
-          class="h-full w-full object-cover"
-          src="https://images.unsplash.com/photo-1525130413817-d45c1d127c42?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1920&q=60&blend=6366F1&sat=-100&blend-mode=multiply"
-          alt=""
-        />
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 926 676"
-          aria-hidden="true"
-          class="absolute left-24 -bottom-24 w-[57.875rem] transform-gpu blur-[118px]"
-        >
-          <path
-            fill="url(#60c3c621-93e0-4a09-a0e6-4c228a0116d8)"
-            fill-opacity=".4"
-            d="m254.325 516.708-90.89 158.331L0 436.427l254.325 80.281 163.691-285.15c1.048 131.759 36.144 345.144 168.149 144.613C751.171 125.508 707.17-93.823 826.603 41.15c95.546 107.978 104.766 294.048 97.432 373.585L685.481 297.694l16.974 360.474-448.13-141.46Z"
-          />
-          <defs>
-            <linearGradient
-              id="60c3c621-93e0-4a09-a0e6-4c228a0116d8"
-              x1="926.392"
-              x2="-109.635"
-              y1=".176"
-              y2="321.024"
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop stop-color="#776FFF"></stop>
-              <stop offset="1" stop-color="#FF4694"></stop>
-            </linearGradient>
-          </defs>
-        </svg>
+    <section id="contact" class="relative isolate overflow-hidden border-t border-border bg-surface/40">
+      <!-- accent glow -->
+      <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 -bottom-48 -z-10 flex justify-center blur-3xl">
+        <div
+          class="aspect-[1100/600] w-[60rem] max-w-none bg-gradient-to-tr from-accent-fill/30 via-accent/20 to-cyan-400/20 opacity-40 bg-[length:200%_200%] animate-gradient-pan"
+        ></div>
       </div>
-      <div class="relative mx-auto max-w-7xl py-24 sm:py-32 lg:py-40 lg:px-8">
-        <div class="pr-6 pl-6 md:ml-auto md:w-2/3 md:pl-16 lg:w-1/2 lg:pl-24 lg:pr-0 xl:pl-32">
-          <h2 class="text-base font-semibold leading-7 text-indigo-400">Contact</h2>
-          <p class="mt-2 text-4xl font-bold tracking-tight text-white">Let's work together</p>
-          <p class="mt-6 text-base leading-7 text-gray-300">If you have something interesting, shoot me an email.</p>
-          <div class="mt-8">
+
+      <div class="mx-auto max-w-7xl px-6 py-20 sm:py-28 lg:px-8">
+        <div class="mx-auto max-w-2xl text-center">
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-accent">Contact</h2>
+          <p class="mt-2 text-3xl font-bold tracking-tight text-fg sm:text-4xl">Let's work together</p>
+          <p class="mt-4 text-lg leading-7 text-fg-muted">If you have something interesting, shoot me an email.</p>
+
+          <div class="mt-8 flex justify-center">
             <a
               href="mailto:dale@dalenguyen.me"
-              class="inline-flex items-center rounded-md bg-white/10 px-3.5 py-1.5 text-base font-semibold leading-7 text-white shadow-sm hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 hover:shadow-glow focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="w-5 h-5 mr-2"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
-                />
+              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
               </svg>
               Email me
             </a>
           </div>
 
-          <!-- Social Media Links -->
-          <div class="mt-8">
-            <p class="text-base leading-7 text-gray-300 mb-4">Or connect with me on social media:</p>
-            <div class="flex space-x-6">
+          <div class="mt-10">
+            <p class="mb-4 text-sm text-fg-muted">Or connect with me on social media:</p>
+            <div class="flex justify-center gap-6">
               <a
                 href="https://www.linkedin.com/in/dalenguyenblogger/"
                 target="_blank"
-                class="text-gray-400 hover:text-indigo-400 transition-colors duration-300"
+                rel="noopener"
+                class="text-fg-muted transition-colors duration-300 hover:text-accent"
               >
                 <span class="sr-only">LinkedIn</span>
-                <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 448 512">
+                <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 448 512" aria-hidden="true">
                   <path
                     d="M100.28 448H7.4V148.9h92.88zM53.79 108.1C24.09 108.1 0 83.5 0 53.8a53.79 53.79 0 0 1 107.58 0c0 29.7-24.1 54.3-53.79 54.3zM447.9 448h-92.68V302.4c0-34.7-.7-79.2-48.29-79.2-48.29 0-55.69 37.7-55.69 76.7V448h-92.78V148.9h89.08v40.8h1.3c12.4-23.5 42.69-48.3 87.88-48.3 94 0 111.28 61.9 111.28 142.3V448z"
                   ></path>
@@ -86,10 +50,11 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
               <a
                 href="https://github.com/dalenguyen"
                 target="_blank"
-                class="text-gray-400 hover:text-indigo-400 transition-colors duration-300"
+                rel="noopener"
+                class="text-fg-muted transition-colors duration-300 hover:text-accent"
               >
                 <span class="sr-only">GitHub</span>
-                <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path
                     fill-rule="evenodd"
                     d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
@@ -100,10 +65,11 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
               <a
                 href="https://twitter.com/dale_nguyen"
                 target="_blank"
-                class="text-gray-400 hover:text-indigo-400 transition-colors duration-300"
+                rel="noopener"
+                class="text-fg-muted transition-colors duration-300 hover:text-accent"
               >
                 <span class="sr-only">Twitter</span>
-                <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path
                     d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"
                   />
@@ -112,10 +78,11 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
               <a
                 href="https://www.youtube.com/@dale_nguyen"
                 target="_blank"
-                class="text-gray-400 hover:text-indigo-400 transition-colors duration-300"
+                rel="noopener"
+                class="text-fg-muted transition-colors duration-300 hover:text-accent"
               >
                 <span class="sr-only">YouTube</span>
-                <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path
                     fill-rule="evenodd"
                     d="M19.812 5.418c.861.23 1.538.907 1.768 1.768C21.998 8.746 22 12 22 12s0 3.255-.418 4.814a2.504 2.504 0 0 1-1.768 1.768c-1.56.419-7.814.419-7.814.419s-6.255 0-7.814-.419a2.505 2.505 0 0 1-1.768-1.768C2 15.255 2 12 2 12s0-3.255.417-4.814a2.507 2.507 0 0 1 1.768-1.768C5.744 5 11.998 5 11.998 5s6.255 0 7.814.418ZM15.194 12 10 15V9l5.194 3Z"
@@ -127,7 +94,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
           </div>
         </div>
       </div>
-    </div>
+    </section>
   `,
 })
 export class ContactComponent {}

--- a/libs/portfolio/home/feature/src/lib/intro/intro.component.ts
+++ b/libs/portfolio/home/feature/src/lib/intro/intro.component.ts
@@ -6,90 +6,76 @@ import { RouterModule } from '@angular/router'
   selector: 'dalenguyen-intro',
   imports: [RouterModule],
   template: `
-    <div id="intro" class="relative isolate overflow-hidden bg-gray-900 py-24 px-6 sm:py-32 lg:px-8">
-      <img
-        src="/assets/images/home/intro.jpg"
-        alt="hero image"
-        class="absolute inset-0 -z-10 h-full w-full object-cover"
-      />
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 1097 845"
+    <section id="intro" class="relative isolate overflow-hidden bg-bg">
+      <!-- Animated accent glow -->
+      <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 -top-48 -z-10 flex justify-center blur-3xl">
+        <div
+          class="aspect-[1100/600] w-[72rem] max-w-none bg-gradient-to-tr from-accent-fill/40 via-accent/30 to-cyan-400/30 opacity-40 bg-[length:200%_200%] animate-gradient-pan"
+        ></div>
+      </div>
+      <!-- Subtle grid texture -->
+      <div
         aria-hidden="true"
-        class="hidden transform-gpu blur-3xl sm:absolute sm:-top-10 sm:right-1/2 sm:-z-10 sm:mr-10 sm:block sm:w-[68.5625rem]"
-      >
-        <path
-          fill="url(#10724532-9d81-43d2-bb94-866e98dd6e42)"
-          fill-opacity=".2"
-          d="M301.174 646.641 193.541 844.786 0 546.172l301.174 100.469 193.845-356.855c1.241 164.891 42.802 431.935 199.124 180.978 195.402-313.696 143.295-588.18 284.729-419.266 113.148 135.13 124.068 367.989 115.378 467.527L811.753 372.553l20.102 451.119-530.681-177.031Z"
+        class="pointer-events-none absolute inset-0 -z-10 opacity-[0.04] [background-image:linear-gradient(to_right,currentColor_1px,transparent_1px),linear-gradient(to_bottom,currentColor_1px,transparent_1px)] [background-size:48px_48px] text-fg"
+      ></div>
+
+      <div class="mx-auto max-w-3xl px-6 py-28 sm:py-36 text-center">
+        <img
+          src="/assets/images/dale-nguyen-avatar.webp"
+          alt="Dale Nguyen"
+          width="96"
+          height="96"
+          class="mx-auto h-20 w-20 rounded-full ring-2 ring-border shadow-lg animate-fade-up"
         />
-        <defs>
-          <linearGradient
-            id="10724532-9d81-43d2-bb94-866e98dd6e42"
-            x1="1097.04"
-            x2="-141.165"
-            y1=".22"
-            y2="363.075"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stop-color="#776FFF"></stop>
-            <stop offset="1" stop-color="#FF4694"></stop>
-          </linearGradient>
-        </defs>
-      </svg>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 1097 845"
-        aria-hidden="true"
-        class="absolute left-1/2 -top-52 -z-10 w-[68.5625rem] -translate-x-1/2 transform-gpu blur-3xl sm:top-[-28rem] sm:ml-16 sm:translate-x-0"
-      >
-        <path
-          fill="url(#8ddc7edb-8983-4cd7-bccb-79ad21097d70)"
-          fill-opacity=".2"
-          d="M301.174 646.641 193.541 844.786 0 546.172l301.174 100.469 193.845-356.855c1.241 164.891 42.802 431.935 199.124 180.978 195.402-313.696 143.295-588.18 284.729-419.266 113.148 135.13 124.068 367.989 115.378 467.527L811.753 372.553l20.102 451.119-530.681-177.031Z"
-        />
-        <defs>
-          <linearGradient
-            id="8ddc7edb-8983-4cd7-bccb-79ad21097d70"
-            x1="1097.04"
-            x2="-141.165"
-            y1=".22"
-            y2="363.075"
-            gradientUnits="userSpaceOnUse"
-          >
-            <stop stop-color="#776FFF"></stop>
-            <stop offset="1" stop-color="#FF4694"></stop>
-          </linearGradient>
-        </defs>
-      </svg>
-      <div class="mx-auto max-w-2xl text-center">
-        <h2 class="text-4xl font-bold tracking-tight text-white sm:text-6xl">Howdy 👋</h2>
-        <p class="my-6 text-lg leading-8 text-gray-300">
-          My name is Dale Nguyen. I am a Toronto based digital architect. My competent professional work environments
-          are Angular, GCP, NodeJS, JavaScript/TypeScript, SQL/NoSQL, HTML 5 and CSS, Linux, Docker...
+
+        <span
+          class="mt-8 inline-flex items-center gap-2 rounded-full border border-border bg-surface/60 px-3 py-1 text-xs font-medium text-fg-muted backdrop-blur animate-fade-up [animation-delay:80ms]"
+        >
+          <span class="h-1.5 w-1.5 rounded-full bg-green-400"></span>
+          Software Engineer · Toronto, Canada
+        </span>
+
+        <h1 class="mt-6 text-4xl font-bold tracking-tight text-fg sm:text-6xl animate-fade-up [animation-delay:160ms]">
+          Howdy <span class="inline-block">👋</span> I'm
+          <span class="bg-gradient-to-r from-accent to-cyan-400 bg-clip-text text-transparent">Dale</span>
+        </h1>
+
+        <p class="mx-auto mt-6 max-w-2xl text-lg leading-8 text-fg-muted animate-fade-up [animation-delay:240ms]">
+          A Toronto-based digital architect building for the web and the agentic era — from Angular, NodeJS and GCP to
+          production AI agents and the Model Context Protocol.
         </p>
 
-        <div>
+        <div class="mt-10 flex flex-wrap items-center justify-center gap-3 animate-fade-up [animation-delay:320ms]">
           <a
-            class="inline-flex items-center rounded border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 hover:shadow-glow focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
             [routerLink]="'/'"
             fragment="contact"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              stroke="currentColor"
-              class="w-6 h-6"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m0 0l6.75-6.75M12 19.5l-6.75-6.75" />
+            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
             </svg>
-            Let's meet
+            Let's work together
+          </a>
+          <a
+            class="inline-flex items-center gap-2 rounded-lg border border-border bg-surface/50 px-5 py-2.5 text-sm font-semibold text-fg transition hover:bg-surface-2 hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            routerLink="/blog"
+          >
+            Read my thoughts
+            <span aria-hidden="true">→</span>
           </a>
         </div>
+
+        <ul class="mt-10 flex flex-wrap items-center justify-center gap-2 animate-fade-up [animation-delay:400ms]">
+          @for (tech of techStack; track tech) {
+            <li class="rounded-full border border-border bg-surface/50 px-3 py-1 text-xs font-medium text-fg-muted">
+              {{ tech }}
+            </li>
+          }
+        </ul>
       </div>
-    </div>
+    </section>
   `,
 })
-export class IntroComponent {}
+export class IntroComponent {
+  readonly techStack = ['Angular', 'GCP', 'Node.js', 'AI Agents', 'MCP', 'TypeScript']
+}

--- a/libs/portfolio/home/feature/src/lib/portfolio/portfolio.component.ts
+++ b/libs/portfolio/home/feature/src/lib/portfolio/portfolio.component.ts
@@ -1,9 +1,5 @@
-
 import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { MatButtonModule } from '@angular/material/button'
-import { MatCardModule } from '@angular/material/card'
-import { MatChipsModule } from '@angular/material/chips'
-import { MatIconModule } from '@angular/material/icon'
+import { RevealDirective } from '@dalenguyen/portfolio/shell/ui'
 
 interface PortfolioItem {
   id: number
@@ -17,65 +13,60 @@ interface PortfolioItem {
 @Component({
   selector: 'dalenguyen-portfolio',
   standalone: true,
-  imports: [MatCardModule, MatButtonModule, MatIconModule, MatChipsModule],
+  imports: [RevealDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <section id="portfolio" class="py-12">
-      <div class="max-w-7xl mx-auto px-4">
+    <section id="portfolio" class="py-16 sm:py-20 bg-surface/30">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <header class="text-center mb-12">
-          <h2 class="text-4xl font-bold mb-4 text-gray-800">Project Gallery</h2>
-          <p class="text-lg text-gray-600 max-w-2xl mx-auto">
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-fg">Project Gallery</h2>
+          <p class="mt-3 text-lg text-fg-muted max-w-2xl mx-auto">
             I create user-centered digital experiences that blend innovative technology with strategic design, focusing
             on intuitive interfaces that drive engagement and deliver measurable business outcomes.
           </p>
         </header>
-    
+
         <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-          @for (project of portfolioItems; track project) {
-            <mat-card
-              class="h-full flex flex-col overflow-hidden rounded-lg transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-              >
-              <img mat-card-image [src]="project.imageUrl" [alt]="project.title" class="h-48 w-full object-cover" />
-              <mat-card-content class="flex-grow p-6">
-                <h3 class="text-2xl font-semibold my-3 text-gray-800">
+          @for (project of portfolioItems; track project.id) {
+            <div
+              dalReveal
+              class="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border bg-surface transition duration-300 hover:-translate-y-1 hover:border-accent hover:shadow-glow"
+            >
+              <div class="relative h-48 overflow-hidden">
+                <img
+                  [src]="project.imageUrl"
+                  [alt]="project.title"
+                  loading="lazy"
+                  class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+                />
+                <div class="absolute inset-0 bg-gradient-to-t from-surface/80 to-transparent"></div>
+              </div>
+              <div class="flex flex-grow flex-col p-6">
+                <h3 class="text-xl font-semibold text-fg">
                   <a
                     [href]="project.projectUrl"
                     target="_blank"
-                    class="hover:text-primary transition-colors duration-300 hover:underline"
-                    >
+                    rel="noopener"
+                    class="transition-colors duration-300 after:absolute after:inset-0 hover:text-accent"
+                  >
                     {{ project.title }}
                   </a>
                 </h3>
-                <p class="text-gray-600 mb-6 leading-relaxed">{{ project.description }}</p>
-                <div class="mb-4 flex flex-wrap gap-2">
-                  @for (tech of project.technologies; track tech) {
-                    <div
-                      class="inline-flex items-center px-3 py-1 rounded-full text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors duration-200"
-                      >
-                      <mat-icon class="h-4 w-4 mr-1 text-gray-600">{{ tech.icon }}</mat-icon>
-                      <span>{{ tech.name }}</span>
-                    </div>
+                <p class="mt-2 flex-grow leading-relaxed text-fg-muted">{{ project.description }}</p>
+                <div class="mt-4 flex flex-wrap gap-2">
+                  @for (tech of project.technologies; track tech.name) {
+                    <span class="rounded-full border border-border bg-surface-2 px-2.5 py-0.5 text-xs font-medium text-fg-muted">
+                      {{ tech.name }}
+                    </span>
                   }
                 </div>
-              </mat-card-content>
-            </mat-card>
+              </div>
+            </div>
           }
         </div>
       </div>
     </section>
-    `,
-  styles: [
-    `
-      mat-icon {
-        font-size: 16px;
-        height: 16px;
-        width: 16px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-    `,
-  ],
+  `,
 })
 export class PortfolioComponent {
   portfolioItems: PortfolioItem[] = [

--- a/libs/portfolio/home/feature/src/lib/publication/publication.component.ts
+++ b/libs/portfolio/home/feature/src/lib/publication/publication.component.ts
@@ -1,8 +1,5 @@
-
 import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { MatButtonModule } from '@angular/material/button'
-import { MatCardModule } from '@angular/material/card'
-import { MatIconModule } from '@angular/material/icon'
+import { RevealDirective } from '@dalenguyen/portfolio/shell/ui'
 
 interface Book {
   title: string
@@ -15,46 +12,49 @@ interface Book {
 
 @Component({
   selector: 'dalenguyen-publication',
-  imports: [MatCardModule, MatButtonModule, MatIconModule],
+  standalone: true,
+  imports: [RevealDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <section id="publication" class="py-12 bg-gray-50">
-      <div class="max-w-7xl mx-auto px-4">
+    <section id="publication" class="py-16 sm:py-20 bg-bg">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <header class="text-center mb-12">
-          <h2 class="text-4xl font-bold mb-4 text-gray-800">Publications</h2>
-          <p class="text-lg text-gray-600 max-w-2xl mx-auto">
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-fg">Publications</h2>
+          <p class="mt-3 text-lg text-fg-muted max-w-2xl mx-auto">
             Sharing knowledge and expertise through technical writing and publications.
           </p>
         </header>
 
-        <div class="max-w-4xl mx-auto">
-          <div class="bg-white rounded-lg shadow-lg overflow-hidden transition-all duration-300 hover:shadow-xl">
-            <a [href]="book.amazonUrl" rel="noopener follow" target="_blank" class="flex flex-col md:flex-row">
-              <div class="md:w-1/3 flex justify-center items-center bg-gray-50">
-                <img [src]="book.imageUrl" alt="Book cover" class="object-contain h-full" loading="lazy" />
+        <div class="max-w-4xl mx-auto" dalReveal>
+          <a
+            [href]="book.amazonUrl"
+            rel="noopener follow"
+            target="_blank"
+            class="group block overflow-hidden rounded-2xl border border-border bg-surface transition duration-300 hover:border-accent hover:shadow-glow"
+          >
+            <div class="flex flex-col md:flex-row">
+              <div class="flex items-center justify-center bg-surface-2 p-6 md:w-1/3">
+                <img [src]="book.imageUrl" alt="Book cover" class="h-56 w-auto object-contain rounded shadow-lg" loading="lazy" />
               </div>
-              <div class="md:w-2/3 p-6 flex flex-col justify-between">
+              <div class="flex flex-col justify-between p-6 md:w-2/3">
                 <div>
-                  <h4
-                    class="text-xl font-semibold mb-3 text-gray-800 hover:text-primary transition-colors duration-300"
-                  >
+                  <h3 class="text-xl font-semibold text-fg transition-colors duration-300 group-hover:text-accent">
                     {{ book.title }}
-                  </h4>
-                  <p class="text-gray-600 mb-4">{{ book.description }}</p>
+                  </h3>
+                  <p class="mt-3 text-fg-muted">{{ book.description }}</p>
                 </div>
-                <div class="flex items-center justify-between">
-                  <div class="flex items-center text-sm text-gray-500">
-                    <span>{{ book.year }}</span>
-                    <span class="mx-2">·</span>
-                    <span>{{ book.author }}</span>
-                  </div>
-                  <div class="flex items-center">
-                    <mat-icon class="text-gray-600">open_in_new</mat-icon>
-                  </div>
+                <div class="mt-5 flex items-center justify-between text-sm text-fg-muted">
+                  <span>{{ book.year }} · {{ book.author }}</span>
+                  <span class="inline-flex items-center gap-1 text-accent">
+                    View on Amazon
+                    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                    </svg>
+                  </span>
                 </div>
               </div>
-            </a>
-          </div>
+            </div>
+          </a>
         </div>
       </div>
     </section>

--- a/libs/portfolio/home/feature/src/lib/recent-posts/recent-posts.component.ts
+++ b/libs/portfolio/home/feature/src/lib/recent-posts/recent-posts.component.ts
@@ -2,6 +2,7 @@ import { injectContentFiles } from '@analogjs/content'
 import { DatePipe, TitleCasePipe } from '@angular/common'
 import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { RouterLink } from '@angular/router'
+import { RevealDirective } from '@dalenguyen/portfolio/shell/ui'
 
 interface PostAttributes {
   title: string
@@ -18,18 +19,16 @@ interface PostAttributes {
 @Component({
   selector: 'dalenguyen-recent-posts',
   standalone: true,
-  imports: [DatePipe, TitleCasePipe, RouterLink],
+  imports: [DatePipe, TitleCasePipe, RouterLink, RevealDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <section class="bg-white py-12">
+    <section class="bg-bg py-16 sm:py-20">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="text-center mb-12">
-          <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-            <span class="block">Latest From The Blog</span>
-          </h2>
-          <p class="mt-3 max-w-2xl mx-auto text-lg text-gray-500">Explore my recent thoughts, tutorials and insights</p>
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-fg">Latest From The Blog</h2>
+          <p class="mt-3 max-w-2xl mx-auto text-lg text-fg-muted">Explore my recent thoughts, tutorials and insights</p>
           <div class="mt-4">
-            <a routerLink="/blog" class="text-indigo-600 hover:text-indigo-800 font-medium transition-colors">
+            <a routerLink="/blog" class="text-accent hover:underline underline-offset-4 font-medium transition-colors">
               View all posts →
             </a>
           </div>
@@ -37,19 +36,21 @@ interface PostAttributes {
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           @for (post of recentPosts; track post.attributes.slug) {
-          <div
-            class="bg-white rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-all duration-300 flex flex-col"
+          <article
+            dalReveal
+            class="group relative flex flex-col overflow-hidden rounded-2xl border border-border bg-surface transition duration-300 hover:-translate-y-1 hover:border-accent hover:shadow-glow"
           >
             <div class="relative h-44 overflow-hidden">
               <img
                 [src]="post.attributes.coverImage"
                 [alt]="post.attributes.title"
-                class="w-full h-full object-cover transform hover:scale-105 transition-transform duration-500"
+                loading="lazy"
+                class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
               />
               @if (post.attributes.categories.length > 0) {
-              <div class="absolute top-0 right-0 mt-3 mr-3">
+              <div class="absolute top-3 right-3">
                 <span
-                  class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800"
+                  class="inline-flex items-center rounded-full bg-bg/70 px-2.5 py-0.5 text-xs font-medium text-fg backdrop-blur ring-1 ring-border"
                 >
                   {{ post.attributes.categories[0] | titlecase }}
                 </span>
@@ -57,39 +58,32 @@ interface PostAttributes {
               }
             </div>
             <div class="p-5 flex-grow">
-              <div class="flex items-center text-sm text-gray-500 mb-2">
+              <div class="flex items-center text-sm text-fg-muted mb-2">
                 <time [attr.datetime]="post.attributes.published">
                   {{ post.attributes.published | date: 'mediumDate' }}
                 </time>
               </div>
-              <a [routerLink]="['/blog', post.attributes.slug]" class="block cursor-pointer">
-                <h3
-                  class="text-lg font-semibold text-gray-900 mb-2 hover:text-indigo-600 transition-colors line-clamp-2"
-                >
+              <h3 class="text-lg font-semibold text-fg mb-2 line-clamp-2 transition-colors group-hover:text-accent">
+                <a [routerLink]="['/blog', post.attributes.slug]" class="after:absolute after:inset-0">
                   {{ post.attributes.title }}
-                </h3>
-                <p class="text-gray-600 mb-3 text-sm line-clamp-2">
-                  {{ post.attributes.description }}
-                </p>
-              </a>
+                </a>
+              </h3>
+              <p class="text-fg-muted mb-3 text-sm line-clamp-2">
+                {{ post.attributes.description }}
+              </p>
             </div>
-            <div class="px-5 pb-5 pt-2 border-t border-gray-100 mt-auto">
+            <div class="px-5 pb-5 pt-2 border-t border-border mt-auto">
               <div class="flex items-center">
                 <img
                   [src]="post.attributes.profileImage"
                   [alt]="'Photo of ' + post.attributes.author"
-                  class="h-7 w-7 rounded-full"
+                  class="h-7 w-7 rounded-full ring-1 ring-border"
                 />
-                <span class="ml-2 text-xs font-medium text-gray-700">{{ post.attributes.author }}</span>
-                <a
-                  [routerLink]="['/blog', post.attributes.slug]"
-                  class="ml-auto text-indigo-600 hover:text-indigo-800 text-xs font-medium transition-colors cursor-pointer"
-                >
-                  Read →
-                </a>
+                <span class="ml-2 text-xs font-medium text-fg-muted">{{ post.attributes.author }}</span>
+                <span class="ml-auto text-accent text-xs font-medium">Read →</span>
               </div>
             </div>
-          </div>
+          </article>
           }
         </div>
       </div>

--- a/libs/portfolio/shared/learn/ai-native-engineering-org.html
+++ b/libs/portfolio/shared/learn/ai-native-engineering-org.html
@@ -18,7 +18,7 @@
     --amber: #fbbf24;
     --red: #f87171;
     --text: #e8e8f0;
-    --muted: #7a7a99;
+    --muted: #9696b0;
     --code-bg: #12121a;
   }
 
@@ -812,7 +812,7 @@
 <div class="tooltip" id="shared-tooltip"></div>
 
 <div style="max-width:920px;margin:0 auto 48px;padding:0 24px;">
-  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#7a7a99;flex-wrap:wrap;">
+  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#9696b0;flex-wrap:wrap;">
     <span>Learning Reference</span>
     <span>·</span>
     <a href="https://claude.com/blog/running-an-ai-native-engineering-org" target="_blank" rel="noopener"

--- a/libs/portfolio/shared/learn/how-github-apps-work.html
+++ b/libs/portfolio/shared/learn/how-github-apps-work.html
@@ -19,7 +19,7 @@
   --amber: #fbbf24;
   --red: #f87171;
   --text: #e8e8f0;
-  --muted: #7a7a99;
+  --muted: #9696b0;
   --code-bg: #12121a;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -605,7 +605,7 @@ https://github.com/login/oauth/authorize?client_id=…&amp;state=…
 </div>
 
 <div style="max-width:920px;margin:0 auto 48px;padding:0 24px;">
-  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#7a7a99;flex-wrap:wrap;">
+  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#9696b0;flex-wrap:wrap;">
     <span>Learning Reference</span>
     <span>·</span>
     <a href="https://docs.github.com/en/apps/overview" target="_blank" rel="noopener"

--- a/libs/portfolio/shared/learn/how-matt-learned-to-ship.html
+++ b/libs/portfolio/shared/learn/how-matt-learned-to-ship.html
@@ -18,7 +18,7 @@
   --amber: #fbbf24;
   --red: #f87171;
   --text: #e8e8f0;
-  --muted: #7a7a99;
+  --muted: #9696b0;
   --code-bg: #12121a;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -449,7 +449,7 @@ p:last-child { margin-bottom: 0; }
 
 <!-- Source Reference -->
 <div style="max-width:920px;margin:0 auto 48px;padding:0 24px;">
-  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#7a7a99;">
+  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#9696b0;">
     <span>Learning Reference</span>
     <span>·</span>
     <a href="https://read.technically.dev/p/how-matt-learned-to-ship" target="_blank" rel="noopener"

--- a/libs/portfolio/shared/learn/linear-speed-interactive.html
+++ b/libs/portfolio/shared/learn/linear-speed-interactive.html
@@ -18,7 +18,7 @@
     --amber: #fbbf24;
     --red: #f87171;
     --text: #e8e8f0;
-    --muted: #7a7a99;
+    --muted: #9696b0;
     --code-bg: #12121a;
   }
 
@@ -1099,7 +1099,7 @@
 </main>
 
 <div style="max-width:920px;margin:0 auto 48px;padding:0 24px;">
-  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#7a7a99;">
+  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#9696b0;">
     <span>Learning Reference</span>
     <span>·</span>
     <a href="https://performance.dev/how-is-linear-so-fast-a-technical-breakdown" target="_blank" rel="noopener" style="color:#5e6ad2;text-decoration:none;font-weight:500;">How's Linear so fast? A technical breakdown — performance.dev</a>

--- a/libs/portfolio/shared/learn/macbook-m4-pro-local-ai.html
+++ b/libs/portfolio/shared/learn/macbook-m4-pro-local-ai.html
@@ -19,7 +19,7 @@
   --amber: #fbbf24;
   --red: #f87171;
   --text: #e8e8f0;
-  --muted: #7a7a99;
+  --muted: #9696b0;
   --code-bg: #12121a;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -744,7 +744,7 @@ python -m mlx_lm.lora \
 
 <!-- Source attribution -->
 <div style="max-width:920px;margin:0 auto 48px;padding:0 24px;">
-  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#7a7a99;">
+  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#9696b0;">
     <span>Learning Reference</span>
     <span>·</span>
     <a href="https://medium.com/@shreetejghodekar/i-cancelled-chatgpt-cursor-and-midjourney-this-week-my-macbook-pro-m4-pro-quietly-replaced-all-91cbd7f3c78b" target="_blank" rel="noopener"

--- a/libs/portfolio/shared/learn/model-names-explained.html
+++ b/libs/portfolio/shared/learn/model-names-explained.html
@@ -18,7 +18,7 @@
     --amber: #fbbf24;
     --red: #f87171;
     --text: #e8e8f0;
-    --muted: #7a7a99;
+    --muted: #9696b0;
     --code-bg: #12121a;
   }
   * { box-sizing: border-box; }
@@ -715,7 +715,7 @@
         <span style="color:var(--muted)">-</span>
         <span style="color:var(--green)">AactiveB</span>
         <span style="color:var(--muted)">-</span>
-        <span style="color:#7a7a99">variant</span>
+        <span style="color:#9696b0">variant</span>
       </div>
 
       <h3>Common variant tags you'll see</h3>
@@ -1121,7 +1121,7 @@
   });
 </script>
 <div style="max-width:920px;margin:0 auto 48px;padding:0 24px;">
-  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#7a7a99;">
+  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#9696b0;">
     <span>Learning Reference</span>
     <span>·</span>
     <a href="https://blog.starmorph.com/blog/llm-model-names-decoded" target="_blank" rel="noopener" style="color:#5e6ad2;text-decoration:none;font-weight:500;">LLM Model Names Decoded: Parameters, Quantization & Formats — StarMorph</a>

--- a/libs/portfolio/shared/learn/private-ai-business-blueprint.html
+++ b/libs/portfolio/shared/learn/private-ai-business-blueprint.html
@@ -18,7 +18,7 @@
   --amber: #fbbf24;
   --red: #f87171;
   --text: #e8e8f0;
-  --muted: #7a7a99;
+  --muted: #9696b0;
   --code-bg: #12121a;
 }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}

--- a/libs/portfolio/shared/learn/salesforce-20k-agent-lessons.html
+++ b/libs/portfolio/shared/learn/salesforce-20k-agent-lessons.html
@@ -19,7 +19,7 @@
   --amber: #fbbf24;
   --red: #f87171;
   --text: #e8e8f0;
-  --muted: #7a7a99;
+  --muted: #9696b0;
   --code-bg: #12121a;
 }
 

--- a/libs/portfolio/shared/learn/skip-level-one-on-ones.html
+++ b/libs/portfolio/shared/learn/skip-level-one-on-ones.html
@@ -18,7 +18,7 @@
     --amber: #fbbf24;
     --red: #f87171;
     --text: #e8e8f0;
-    --muted: #7a7a99;
+    --muted: #9696b0;
     --code-bg: #12121a;
   }
 
@@ -873,7 +873,7 @@
 </main>
 
 <div style="max-width:920px;margin:0 auto 48px;padding:0 24px;">
-  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#7a7a99;">
+  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#9696b0;">
     <span>Learning Reference</span>
     <span>·</span>
     <a href="https://mgrebler.substack.com/p/the-secret-to-skip-level-one-on-ones" target="_blank" rel="noopener"

--- a/libs/portfolio/shared/learn/tax-agents-codex.html
+++ b/libs/portfolio/shared/learn/tax-agents-codex.html
@@ -11,7 +11,7 @@
   --bg: #0f0f13; --surface: #1a1a22; --surface2: #22222e; --border: #2e2e3e;
   --accent: #5e6ad2; --accent-glow: rgba(94,106,210,0.25);
   --green: #4ade80; --amber: #fbbf24; --red: #f87171;
-  --text: #e8e8f0; --muted: #7a7a99; --code-bg: #12121a;
+  --text: #e8e8f0; --muted: #9696b0; --code-bg: #12121a;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
 body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; }
@@ -654,7 +654,7 @@ window.addEventListener('load', () => {
 });
 </script>
 <div style="max-width:920px;margin:0 auto 48px;padding:0 24px;">
-  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#7a7a99;">
+  <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#9696b0;">
     <span>Learning Reference</span>
     <span>·</span>
     <a href="https://openai.com/index/building-self-improving-tax-agents-with-codex/" target="_blank" rel="noopener" style="color:#5e6ad2;text-decoration:none;font-weight:500;">Building self-improving tax agents with Codex — OpenAI</a>

--- a/libs/portfolio/shared/learn/turboquant-vector-quantization.html
+++ b/libs/portfolio/shared/learn/turboquant-vector-quantization.html
@@ -1,0 +1,1212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TurboQuant: Vector Quantization for LLM Efficiency</title>
+  <meta name="description" content="Learn how TurboQuant compresses high-dimensional vectors using two-stage quantization and random rotation, with real-world applications in LLM key-value cache compression.">
+  <meta name="date" content="2026-06-12">
+  <meta name="timestamp" content="2026-06-12T12:00:00">
+  <style>
+    :root {
+      --bg-primary: #0a0a0a;
+      --bg-secondary: #1a1a2e;
+      --bg-tertiary: #25254a;
+      --text-primary: #f5f5f5;
+      --text-secondary: #a0a0b0;
+      --accent: #5e6ad2;
+      --accent-hover: #7281e0;
+      --success: #4ade80;
+      --error: #f87171;
+      --border: #2e2e3e;
+      --border-light: #3e3e50;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      background-color: var(--bg-primary);
+      color: var(--text-primary);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      font-size: 16px;
+    }
+
+    .container {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    .hero {
+      padding: 80px 0 40px;
+      text-align: center;
+    }
+
+    .hero-label {
+      display: inline-block;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      color: var(--accent);
+      margin-bottom: 16px;
+      text-transform: uppercase;
+    }
+
+    .hero h1 {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      background: linear-gradient(135deg, #5e6ad2 0%, #a78bfa 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero p {
+      font-size: 18px;
+      color: var(--text-secondary);
+      margin-bottom: 32px;
+      max-width: 600px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .progress-bar {
+      height: 4px;
+      background-color: var(--border);
+      border-radius: 2px;
+      overflow: hidden;
+      margin-bottom: 32px;
+    }
+
+    .progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #5e6ad2 0%, #a78bfa 100%);
+      transition: width 0.3s ease;
+    }
+
+    .progress-text {
+      font-size: 12px;
+      color: var(--text-secondary);
+      text-align: center;
+      margin-top: 8px;
+    }
+
+    .sections {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+      padding: 40px 0;
+    }
+
+    .section {
+      background-color: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      transition: all 0.2s ease;
+    }
+
+    .section-header {
+      padding: 24px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      user-select: none;
+      transition: background-color 0.2s ease;
+      gap: 16px;
+    }
+
+    .section-header:hover {
+      background-color: var(--bg-tertiary);
+    }
+
+    .section-title-wrapper {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex: 1;
+    }
+
+    .section-title {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .section-number {
+      width: 28px;
+      height: 28px;
+      min-width: 28px;
+      background-color: var(--accent);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      font-weight: 700;
+      color: var(--bg-primary);
+    }
+
+    .section-toggle {
+      width: 24px;
+      height: 24px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.2s ease;
+      color: var(--text-secondary);
+    }
+
+    .section.open .section-toggle {
+      transform: rotate(180deg);
+    }
+
+    .section-content {
+      max-height: 0;
+      overflow: hidden;
+      transition: max-height 0.3s ease;
+    }
+
+    .section.open .section-content {
+      max-height: 2000px;
+    }
+
+    .section-body {
+      padding: 24px;
+      border-top: 1px solid var(--border);
+    }
+
+    .section-text {
+      color: var(--text-secondary);
+      margin-bottom: 24px;
+      line-height: 1.7;
+    }
+
+    .callout {
+      background-color: var(--bg-tertiary);
+      border-left: 4px solid var(--accent);
+      padding: 16px;
+      border-radius: 4px;
+      margin-bottom: 24px;
+      font-size: 14px;
+    }
+
+    .tabs {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 24px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .tab-button {
+      padding: 12px 16px;
+      background: none;
+      border: none;
+      color: var(--text-secondary);
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      transition: all 0.2s ease;
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .tab-button.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+
+    .tab-content {
+      display: none;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    .demo {
+      background-color: var(--bg-tertiary);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 24px;
+      position: relative;
+    }
+
+    .demo-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 16px;
+    }
+
+    .demo-canvas {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+
+    .demo-controls {
+      display: flex;
+      gap: 12px;
+      margin-top: 16px;
+      flex-wrap: wrap;
+    }
+
+    .demo-button {
+      padding: 10px 16px;
+      background-color: var(--accent);
+      color: var(--bg-primary);
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-weight: 500;
+      font-size: 14px;
+      transition: background-color 0.2s ease;
+    }
+
+    .demo-button:hover {
+      background-color: var(--accent-hover);
+    }
+
+    .demo-slider {
+      width: 100%;
+      height: 6px;
+      border-radius: 3px;
+      background: linear-gradient(90deg, var(--border) 0%, var(--accent) 50%, var(--border) 100%);
+      outline: none;
+      -webkit-appearance: none;
+      appearance: none;
+      margin-top: 12px;
+    }
+
+    .demo-slider::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: var(--accent);
+      cursor: pointer;
+    }
+
+    .demo-slider::-moz-range-thumb {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: var(--accent);
+      cursor: pointer;
+      border: none;
+    }
+
+    .demo-stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+      margin-top: 16px;
+    }
+
+    .stat-box {
+      background-color: var(--bg-secondary);
+      border: 1px solid var(--border);
+      padding: 12px;
+      border-radius: 6px;
+      text-align: center;
+    }
+
+    .stat-label {
+      font-size: 12px;
+      color: var(--text-secondary);
+      margin-bottom: 4px;
+    }
+
+    .stat-value {
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--accent);
+    }
+
+    .quiz {
+      background-color: var(--bg-tertiary);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 20px;
+      margin-top: 24px;
+    }
+
+    .quiz-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 16px;
+    }
+
+    .quiz-question {
+      font-size: 15px;
+      font-weight: 500;
+      color: var(--text-primary);
+      margin-bottom: 16px;
+    }
+
+    .quiz-options {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .quiz-option {
+      padding: 12px;
+      background-color: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      font-size: 14px;
+      color: var(--text-primary);
+    }
+
+    .quiz-option:hover {
+      border-color: var(--accent);
+      background-color: var(--bg-secondary);
+    }
+
+    .quiz-option.selected {
+      border-color: var(--accent);
+      background-color: var(--bg-tertiary);
+    }
+
+    .quiz-option.correct {
+      border-color: var(--success);
+      background-color: rgba(74, 222, 128, 0.1);
+    }
+
+    .quiz-option.incorrect {
+      border-color: var(--error);
+      background-color: rgba(248, 113, 113, 0.1);
+    }
+
+    .quiz-feedback {
+      margin-top: 12px;
+      padding: 12px;
+      border-radius: 6px;
+      font-size: 14px;
+      display: none;
+    }
+
+    .quiz-feedback.show {
+      display: block;
+    }
+
+    .quiz-feedback.success {
+      background-color: rgba(74, 222, 128, 0.1);
+      border: 1px solid var(--success);
+      color: var(--success);
+    }
+
+    .quiz-feedback.error {
+      background-color: rgba(248, 113, 113, 0.1);
+      border: 1px solid var(--error);
+      color: var(--error);
+    }
+
+    .completion {
+      text-align: center;
+      padding: 60px 24px;
+      display: none;
+    }
+
+    .completion.show {
+      display: block;
+    }
+
+    .completion-icon {
+      font-size: 64px;
+      margin-bottom: 24px;
+    }
+
+    .completion h2 {
+      font-size: 32px;
+      margin-bottom: 12px;
+      background: linear-gradient(135deg, #5e6ad2 0%, #a78bfa 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .completion p {
+      font-size: 16px;
+      color: var(--text-secondary);
+      margin-bottom: 32px;
+    }
+
+    .tooltip {
+      position: fixed;
+      background-color: var(--bg-tertiary);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 8px 12px;
+      font-size: 12px;
+      color: var(--text-secondary);
+      pointer-events: none;
+      z-index: 1000;
+      white-space: nowrap;
+      display: none;
+    }
+
+    .tooltip.show {
+      display: block;
+    }
+
+    .tooltip-arrow {
+      position: absolute;
+      width: 6px;
+      height: 6px;
+      background-color: var(--bg-tertiary);
+      border: 1px solid var(--border);
+      transform: rotate(45deg);
+    }
+
+    @media (max-width: 600px) {
+      .hero h1 {
+        font-size: 32px;
+      }
+
+      .hero p {
+        font-size: 16px;
+      }
+
+      .section-header {
+        flex-direction: row;
+      }
+
+      .demo-stats {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="hero">
+      <span class="hero-label">Compression · 2026</span>
+      <h1>TurboQuant: Vector Quantization for LLM Efficiency</h1>
+      <p>Learn how to compress high-dimensional vectors into low-bitwidth representations while preserving geometric properties—essential for optimizing LLM key-value cache and vector search.</p>
+      <div class="progress-bar">
+        <div class="progress-fill" style="width: 0%"></div>
+      </div>
+      <div class="progress-text"><span class="progress-count">0</span> / 5 sections completed</div>
+    </div>
+
+    <div class="sections">
+      <!-- Section 1: What is Vector Quantization -->
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title-wrapper">
+            <span class="section-number">1</span><span class="section-title">What is Vector Quantization?</span>
+          </div>
+          <div class="section-toggle">▼</div>
+        </div>
+        <div class="section-content">
+          <div class="section-body">
+            <p class="section-text">
+              Vector quantization is the process of mapping vectors from a high-dimensional continuous space into a discrete set of codewords. Think of it as lossy compression: you're replacing precise floating-point coordinates with indices into a smaller "codebook."
+            </p>
+
+            <div class="callout">
+              <strong>Why it matters:</strong> In LLMs, key-value caches during inference can consume massive amounts of memory. For a 70B parameter model, this can be 30–50% of peak memory usage. Vector quantization reduces this without severely degrading model quality.
+            </div>
+
+            <p class="section-text">
+              Traditional quantization methods often fail to preserve geometric properties that matter for downstream tasks. You need the <em>distances</em> and <em>inner products</em> between vectors to remain approximately correct after quantization—especially for retrieval-based systems.
+            </p>
+
+            <div class="demo">
+              <div class="demo-title">Interactive Demo: Vector Compression Trade-off</div>
+              <svg class="demo-canvas" viewBox="0 0 500 300" style="height: 250px;">
+                <!-- Background -->
+                <rect width="500" height="300" fill="#1a1a2e"/>
+
+                <!-- Axes -->
+                <line x1="60" y1="250" x2="480" y2="250" stroke="#2e2e3e" stroke-width="2"/>
+                <line x1="60" y1="20" x2="60" y2="250" stroke="#2e2e3e" stroke-width="2"/>
+                <text x="490" y="270" font-size="12" fill="#a0a0b0">Bitwidth (bits)</text>
+                <text x="20" y="15" font-size="12" fill="#a0a0b0">Error Rate (%)</text>
+
+                <!-- Grid lines -->
+                <line x1="60" y1="170" x2="480" y2="170" stroke="#25254a" stroke-width="1" stroke-dasharray="4"/>
+                <line x1="60" y1="90" x2="480" y2="90" stroke="#25254a" stroke-width="1" stroke-dasharray="4"/>
+
+                <!-- Curve for quantization error -->
+                <path d="M 80 50 Q 200 100 400 200" stroke="none" fill="url(#grad)" opacity="0.3"/>
+                <polyline points="80,50 150,80 220,120 290,160 360,190 400,210" stroke="#5e6ad2" stroke-width="2" fill="none"/>
+
+                <!-- Points on curve -->
+                <circle cx="80" cy="50" r="5" fill="#5e6ad2" class="demo-point"/>
+                <circle cx="150" cy="80" r="5" fill="#5e6ad2" class="demo-point"/>
+                <circle cx="220" cy="120" r="5" fill="#5e6ad2" class="demo-point"/>
+                <circle cx="290" cy="160" r="5" fill="#5e6ad2" class="demo-point"/>
+                <circle cx="360" cy="190" r="5" fill="#5e6ad2" class="demo-point"/>
+
+                <!-- Axis labels -->
+                <text x="100" y="270" font-size="11" fill="#9696b0">1</text>
+                <text x="180" y="270" font-size="11" fill="#9696b0">2</text>
+                <text x="260" y="270" font-size="11" fill="#9696b0">4</text>
+                <text x="360" y="270" font-size="11" fill="#9696b0">8</text>
+                <text x="420" y="270" font-size="11" fill="#9696b0">16</text>
+
+                <text x="35" y="260" font-size="11" fill="#9696b0">0%</text>
+                <text x="35" y="180" font-size="11" fill="#9696b0">25%</text>
+                <text x="35" y="100" font-size="11" fill="#9696b0">50%</text>
+
+                <defs>
+                  <linearGradient id="grad" x1="0%" y1="0%" x2="0%" y2="100%">
+                    <stop offset="0%" style="stop-color:#5e6ad2;stop-opacity:0.3" />
+                    <stop offset="100%" style="stop-color:#5e6ad2;stop-opacity:0" />
+                  </linearGradient>
+                </defs>
+              </svg>
+              <div class="demo-stats">
+                <div class="stat-box">
+                  <div class="stat-label">Compression Ratio</div>
+                  <div class="stat-value" id="compressionRatio">4x</div>
+                </div>
+                <div class="stat-box">
+                  <div class="stat-label">Memory Saved</div>
+                  <div class="stat-value" id="memorySaved">75%</div>
+                </div>
+                <div class="stat-box">
+                  <div class="stat-label">Error Rate</div>
+                  <div class="stat-value" id="errorRate">~20%</div>
+                </div>
+              </div>
+              <input type="range" min="1" max="16" value="4" class="demo-slider" id="bitwidthSlider"/>
+              <div style="font-size: 12px; color: #9696b0; margin-top: 8px; text-align: center;">Slide to adjust bitwidth</div>
+            </div>
+
+            <div class="quiz">
+              <div class="quiz-title">Check Your Understanding</div>
+              <div class="quiz-question">Why is preserving inner products important in vector quantization for LLMs?</div>
+              <div class="quiz-options">
+                <div class="quiz-option" data-correct="false">To ensure the quantized codebook is sorted</div>
+                <div class="quiz-option" data-correct="true">Because inner products determine relevance scores in attention mechanisms and retrieval</div>
+                <div class="quiz-option" data-correct="false">To reduce the computational cost of quantization itself</div>
+                <div class="quiz-option" data-correct="false">It's only important for very large models</div>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Section 2: Two-Stage Quantization -->
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title-wrapper">
+            <span class="section-number">2</span><span class="section-title">The Two-Stage Quantization Approach</span>
+          </div>
+          <div class="section-toggle">▼</div>
+        </div>
+        <div class="section-content">
+          <div class="section-body">
+            <p class="section-text">
+              TurboQuant doesn't use a single quantizer for all objectives. Instead, it creates two independent quantizers: one optimized for mean-squared error (MSE), and another specifically designed to preserve inner products.
+            </p>
+
+            <div class="callout">
+              <strong>Key insight:</strong> MSE loss and inner product preservation require different codebook designs. MSE minimizes coordinate-wise errors, while inner product preservation must account for how all coordinates interact.
+            </div>
+
+            <div class="tabs">
+              <button class="tab-button active" data-tab="stage1">Stage 1: MSE Quantizer</button>
+              <button class="tab-button" data-tab="stage2">Stage 2: Inner Product Quantizer</button>
+            </div>
+
+            <div id="stage1" class="tab-content active">
+              <p class="section-text">
+                The first stage uses a standard scalar quantizer optimized for MSE. Each coordinate is independently quantized to a discrete level, minimizing reconstruction error. This produces a first approximation of the original vector.
+              </p>
+            </div>
+
+            <div id="stage2" class="tab-content">
+              <p class="section-text">
+                The second stage quantizes the <em>residuals</em> (difference between original and Stage 1 output) using a 1-bit Quantized Johnson-Lindenstrauss transform. This focuses on preserving the directional information critical for inner products, not the magnitude.
+              </p>
+            </div>
+
+            <div class="demo">
+              <div class="demo-title">Interactive Demo: Two-Stage Decomposition</div>
+              <svg class="demo-canvas" viewBox="0 0 500 280" style="height: 280px;">
+                <!-- Background -->
+                <rect width="500" height="280" fill="#1a1a2e"/>
+
+                <!-- Stage 1 -->
+                <g>
+                  <rect x="30" y="20" width="180" height="80" fill="none" stroke="#5e6ad2" stroke-width="2" stroke-dasharray="4"/>
+                  <text x="50" y="45" font-size="14" font-weight="600" fill="#5e6ad2">Stage 1: MSE</text>
+                  <text x="50" y="70" font-size="12" fill="#a0a0b0">Codebook: 256 levels</text>
+                  <text x="50" y="90" font-size="12" fill="#a0a0b0">Loss: MSE</text>
+                </g>
+
+                <!-- Arrow -->
+                <path d="M 220 60 L 260 60" stroke="#a0a0b0" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+
+                <!-- Stage 2 -->
+                <g>
+                  <rect x="280" y="20" width="180" height="80" fill="none" stroke="#a78bfa" stroke-width="2" stroke-dasharray="4"/>
+                  <text x="300" y="45" font-size="14" font-weight="600" fill="#a78bfa">Stage 2: Inner Product</text>
+                  <text x="300" y="70" font-size="12" fill="#a0a0b0">Codebook: 2 levels (1-bit)</text>
+                  <text x="300" y="90" font-size="12" fill="#a0a0b0">Loss: Unbiased IP estimate</text>
+                </g>
+
+                <!-- Input vector -->
+                <g>
+                  <text x="50" y="140" font-size="12" font-weight="600" fill="#5e6ad2">Input Vector</text>
+                  <rect x="30" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.3"/>
+                  <rect x="55" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.3"/>
+                  <rect x="80" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.3"/>
+                  <rect x="105" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.3"/>
+                  <rect x="130" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.3"/>
+                </g>
+
+                <!-- After Stage 1 -->
+                <g>
+                  <text x="280" y="140" font-size="12" font-weight="600" fill="#5e6ad2">After Stage 1</text>
+                  <rect x="280" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.7"/>
+                  <rect x="305" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.7"/>
+                  <rect x="330" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.7"/>
+                  <rect x="355" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.7"/>
+                  <rect x="380" y="150" width="20" height="20" fill="#5e6ad2" opacity="0.7"/>
+                </g>
+
+                <!-- After Stage 2 -->
+                <g>
+                  <text x="280" y="220" font-size="12" font-weight="600" fill="#a78bfa">After Stage 2</text>
+                  <rect x="280" y="230" width="20" height="20" fill="#a78bfa" opacity="0.7"/>
+                  <rect x="305" y="230" width="20" height="20" fill="#a78bfa" opacity="0.7"/>
+                  <rect x="330" y="230" width="20" height="20" fill="#a78bfa" opacity="0.7"/>
+                  <rect x="355" y="230" width="20" height="20" fill="#a78bfa" opacity="0.7"/>
+                  <rect x="380" y="230" width="20" height="20" fill="#a78bfa" opacity="0.7"/>
+                </g>
+
+                <defs>
+                  <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+                    <polygon points="0 0, 10 3, 0 6" fill="#a0a0b0"/>
+                  </marker>
+                </defs>
+              </svg>
+              <div class="demo-stats">
+                <div class="stat-box">
+                  <div class="stat-label">Stage 1 Error</div>
+                  <div class="stat-value" id="stage1Error">3.2%</div>
+                </div>
+                <div class="stat-box">
+                  <div class="stat-label">Stage 2 Bits</div>
+                  <div class="stat-value" id="stage2Bits">1</div>
+                </div>
+                <div class="stat-box">
+                  <div class="stat-label">Total Bitwidth</div>
+                  <div class="stat-value" id="totalBits">9</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="quiz">
+              <div class="quiz-title">Check Your Understanding</div>
+              <div class="quiz-question">Why does Stage 2 only use 1 bit per dimension, while Stage 1 uses 256 levels?</div>
+              <div class="quiz-options">
+                <div class="quiz-option" data-correct="true">Because Stage 2 only needs to encode the sign of residuals for directional information, not precise magnitude</div>
+                <div class="quiz-option" data-correct="false">Because Stage 2 is always applied to smaller vectors</div>
+                <div class="quiz-option" data-correct="false">1-bit quantization is always faster than multi-bit</div>
+                <div class="quiz-option" data-correct="false">Stage 2 is optional and can be skipped for small models</div>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Section 3: Random Rotation & Coordinate Independence -->
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title-wrapper">
+            <span class="section-number">3</span><span class="section-title">Random Rotation & Coordinate Independence</span>
+          </div>
+          <div class="section-toggle">▼</div>
+        </div>
+        <div class="section-content">
+          <div class="section-body">
+            <p class="section-text">
+              The trick that makes TurboQuant work is applying a <strong>random orthogonal rotation</strong> to the input vectors before quantization. After rotation, each coordinate approximately follows a Beta distribution that converges to Gaussian in high dimensions, making coordinates nearly independent.
+            </p>
+
+            <div class="callout">
+              <strong>Why this matters:</strong> Independent coordinates can be quantized separately using scalar quantizers, which are both theoretically optimal and computationally efficient. Correlated coordinates would require expensive vector quantizers.
+            </div>
+
+            <p class="section-text">
+              Since the rotation is random and fixed per model, it can be applied once during preprocessing. Quantization then happens coordinate-by-coordinate, with each scalar quantizer optimized independently.
+            </p>
+
+            <div class="demo">
+              <div class="demo-title">Interactive Demo: Effect of Random Rotation</div>
+              <svg class="demo-canvas" viewBox="0 0 500 380" style="height: 380px;">
+                <!-- Background -->
+                <rect width="500" height="380" fill="#1a1a2e"/>
+
+                <!-- Left plot: Original correlated data -->
+                <g>
+                  <text x="40" y="25" font-size="13" font-weight="600" fill="#5e6ad2">Original Vectors</text>
+                  <rect x="20" y="40" width="200" height="160" fill="none" stroke="#2e2e3e" stroke-width="1"/>
+
+                  <!-- Correlated data cloud -->
+                  <circle cx="70" cy="130" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="75" cy="125" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="80" cy="120" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="85" cy="115" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="90" cy="110" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="100" cy="100" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="110" cy="90" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="120" cy="80" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="130" cy="70" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="140" cy="60" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="150" cy="50" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="160" cy="80" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="170" cy="70" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="180" cy="60" r="3" fill="#5e6ad2" opacity="0.6"/>
+                  <circle cx="190" cy="50" r="3" fill="#5e6ad2" opacity="0.6"/>
+
+                  <text x="40" y="215" font-size="11" fill="#9696b0">High correlation</text>
+                  <text x="40" y="230" font-size="11" fill="#9696b0">between dims</text>
+                </g>
+
+                <!-- Right plot: After rotation -->
+                <g>
+                  <text x="280" y="25" font-size="13" font-weight="600" fill="#a78bfa">After Random Rotation</text>
+                  <rect x="260" y="40" width="200" height="160" fill="none" stroke="#2e2e3e" stroke-width="1"/>
+
+                  <!-- Independent data cloud -->
+                  <circle cx="310" cy="100" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="320" cy="130" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="330" cy="70" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="340" cy="110" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="350" cy="150" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="300" cy="80" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="315" cy="160" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="325" cy="90" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="335" cy="140" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="345" cy="60" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="310" cy="120" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="320" cy="50" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="330" cy="140" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="340" cy="80" r="3" fill="#a78bfa" opacity="0.6"/>
+                  <circle cx="350" cy="110" r="3" fill="#a78bfa" opacity="0.6"/>
+
+                  <text x="280" y="215" font-size="11" fill="#9696b0">Nearly independent</text>
+                  <text x="280" y="230" font-size="11" fill="#9696b0">dimensions</text>
+                </g>
+
+                <!-- Distribution plots -->
+                <g>
+                  <text x="40" y="280" font-size="11" font-weight="600" fill="#5e6ad2">Dimension 1</text>
+                  <rect x="20" y="295" width="200" height="50" fill="none" stroke="#2e2e3e" stroke-width="1"/>
+                  <path d="M 30 330 Q 50 310 70 305 Q 90 305 110 310 Q 130 320 150 330 Q 170 335 190 330" stroke="#5e6ad2" stroke-width="2" fill="none"/>
+                </g>
+
+                <g>
+                  <text x="280" y="280" font-size="11" font-weight="600" fill="#a78bfa">After Rotation</text>
+                  <rect x="260" y="295" width="200" height="50" fill="none" stroke="#2e2e3e" stroke-width="1"/>
+                  <path d="M 270 325 Q 290 310 310 305 Q 330 305 350 310 Q 370 320 390 325 Q 410 320 430 315" stroke="#a78bfa" stroke-width="2" fill="none"/>
+                </g>
+              </svg>
+              <div class="demo-stats">
+                <div class="stat-box">
+                  <div class="stat-label">Correlation Before</div>
+                  <div class="stat-value" id="corrBefore">0.87</div>
+                </div>
+                <div class="stat-box">
+                  <div class="stat-label">Correlation After</div>
+                  <div class="stat-value" id="corrAfter">0.02</div>
+                </div>
+                <div class="stat-box">
+                  <div class="stat-label">Quantization Efficiency</div>
+                  <div class="stat-value" id="efficiency">92%</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="quiz">
+              <div class="quiz-title">Check Your Understanding</div>
+              <div class="quiz-question">Why is a random orthogonal rotation preferred over other decorrelation methods?</div>
+              <div class="quiz-options">
+                <div class="quiz-option" data-correct="false">It's faster than PCA</div>
+                <div class="quiz-option" data-correct="true">It doesn't require learning from data, preserves distances (orthogonal), and can be fixed during training</div>
+                <div class="quiz-option" data-correct="false">It guarantees perfect independence between all coordinates</div>
+                <div class="quiz-option" data-correct="false">It reduces the dimension of the vectors</div>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Section 4: Theoretical Guarantees -->
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title-wrapper">
+            <span class="section-number">4</span><span class="section-title">Theoretical Guarantees & Bounds</span>
+          </div>
+          <div class="section-toggle">▼</div>
+        </div>
+        <div class="section-content">
+          <div class="section-body">
+            <p class="section-text">
+              TurboQuant comes with rigorous theoretical analysis. The paper proves that the method achieves distortion within a <strong>constant factor (~2.7×)</strong> of the information-theoretic lower bounds. This means you're not far from the theoretical optimum.
+            </p>
+
+            <div class="callout">
+              <strong>What this means:</strong> No algorithm can do better than certain theoretical bounds. TurboQuant's guarantee of 2.7× overhead is quite good—it's close enough to be nearly optimal across all bit-widths.
+            </div>
+
+            <p class="section-text">
+              The lower bounds come from rate-distortion theory: the number of bits required to compress a vector to a given error level. TurboQuant's theoretical guarantees hold for both MSE and inner product preservation objectives.
+            </p>
+
+            <div class="demo">
+              <div class="demo-title">Interactive Demo: Distortion vs Information-Theoretic Bounds</div>
+              <svg class="demo-canvas" viewBox="0 0 500 300" style="height: 280px;">
+                <!-- Background -->
+                <rect width="500" height="300" fill="#1a1a2e"/>
+
+                <!-- Axes -->
+                <line x1="60" y1="250" x2="480" y2="250" stroke="#2e2e3e" stroke-width="2"/>
+                <line x1="60" y1="30" x2="60" y2="250" stroke="#2e2e3e" stroke-width="2"/>
+                <text x="490" y="270" font-size="12" fill="#a0a0b0">Bitwidth (bits/dim)</text>
+                <text x="10" y="25" font-size="12" fill="#a0a0b0">Distortion (log scale)</text>
+
+                <!-- Grid -->
+                <line x1="60" y1="180" x2="480" y2="180" stroke="#25254a" stroke-width="1" stroke-dasharray="4"/>
+                <line x1="60" y1="110" x2="480" y2="110" stroke="#25254a" stroke-width="1" stroke-dasharray="4"/>
+
+                <!-- Lower bound (optimal) -->
+                <polyline points="80,220 150,180 220,150 290,120 360,100 420,80" stroke="#4ade80" stroke-width="2" fill="none" stroke-dasharray="6"/>
+                <text x="430" y="75" font-size="11" fill="#4ade80">Lower Bound</text>
+
+                <!-- TurboQuant curve (2.7x overhead) -->
+                <polyline points="80,185 150,155 220,125 290,100 360,80 420,65" stroke="#5e6ad2" stroke-width="3" fill="none"/>
+                <text x="300" y="45" font-size="11" fill="#5e6ad2">TurboQuant (2.7x)</text>
+
+                <!-- Other method (higher overhead) -->
+                <polyline points="80,160 150,130 220,100 290,75 360,55 420,40" stroke="#f87171" stroke-width="2" fill="none" stroke-dasharray="4"/>
+                <text x="360" y="30" font-size="11" fill="#f87171">Other Methods (4x+)</text>
+
+                <!-- Axis labels -->
+                <text x="85" y="270" font-size="11" fill="#9696b0">1</text>
+                <text x="165" y="270" font-size="11" fill="#9696b0">2</text>
+                <text x="245" y="270" font-size="11" fill="#9696b0">4</text>
+                <text x="325" y="270" font-size="11" fill="#9696b0">8</text>
+                <text x="405" y="270" font-size="11" fill="#9696b0">16</text>
+              </svg>
+              <div class="demo-stats">
+                <div class="stat-box">
+                  <div class="stat-label">Optimality Gap</div>
+                  <div class="stat-value" id="optGap">2.7x</div>
+                </div>
+                <div class="stat-box">
+                  <div class="stat-label">Bitwidth</div>
+                  <div class="stat-value" id="demoBitwidth">4</div>
+                </div>
+                <div class="stat-box">
+                  <div class="stat-label">Distortion</div>
+                  <div class="stat-value" id="demoDistortion">0.125</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="quiz">
+              <div class="quiz-title">Check Your Understanding</div>
+              <div class="quiz-question">What does it mean that TurboQuant achieves ~2.7× the information-theoretic lower bound?</div>
+              <div class="quiz-options">
+                <div class="quiz-option" data-correct="true">No algorithm can compress better than the lower bound; TurboQuant is only 2.7× worse, which is nearly optimal</div>
+                <div class="quiz-option" data-correct="false">TurboQuant performs 2.7× worse than any other quantization method</div>
+                <div class="quiz-option" data-correct="false">The method requires 2.7× more bits than alternatives</div>
+                <div class="quiz-option" data-correct="false">This guarantee only holds for very high bitwidths</div>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Section 5: Real-World Applications -->
+      <div class="section">
+        <div class="section-header">
+          <div class="section-title-wrapper">
+            <span class="section-number">5</span><span class="section-title">Real-World Applications</span>
+          </div>
+          <div class="section-toggle">▼</div>
+        </div>
+        <div class="section-content">
+          <div class="section-body">
+            <p class="section-text">
+              TurboQuant's practical impact is massive. The paper demonstrates 4–5× compression of LLM key-value caches with minimal quality loss, and 2.5–3.5 bits per channel on LongBench tasks. This directly translates to reduced memory requirements and faster inference.
+            </p>
+
+            <div class="callout">
+              <strong>Real impact:</strong> For a 70B-parameter model serving long-context requests, KV cache compression can reduce memory by 30–50%, allowing longer context windows or higher batch sizes on the same hardware.
+            </div>
+
+            <p class="section-text">
+              Additionally, TurboQuant outperforms Product Quantization (PQ) in nearest neighbor search while requiring negligible indexing time. This makes it ideal for vector databases and semantic search applications.
+            </p>
+
+            <div class="tabs">
+              <button class="tab-button active" data-tab="kvcache">KV Cache Compression</button>
+              <button class="tab-button" data-tab="search">Vector Search</button>
+            </div>
+
+            <div id="kvcache" class="tab-content active">
+              <div class="demo">
+                <div class="demo-title">LLM KV Cache Compression Results</div>
+                <svg class="demo-canvas" viewBox="0 0 500 280" style="height: 280px;">
+                  <!-- Background -->
+                  <rect width="500" height="280" fill="#1a1a2e"/>
+
+                  <!-- Title -->
+                  <text x="50" y="30" font-size="14" font-weight="600" fill="#5e6ad2">Memory Usage by Quantization Level</text>
+
+                  <!-- Bars -->
+                  <g>
+                    <!-- Uncompressed -->
+                    <rect x="40" y="80" width="40" height="140" fill="#5e6ad2" opacity="0.3"/>
+                    <text x="45" y="230" font-size="12" fill="#5e6ad2" font-weight="600">FP32</text>
+                    <text x="30" y="75" font-size="11" fill="#a0a0b0">100%</text>
+
+                    <!-- 4x compression -->
+                    <rect x="110" y="150" width="40" height="70" fill="#5e6ad2" opacity="0.6"/>
+                    <text x="110" y="230" font-size="12" fill="#5e6ad2" font-weight="600">4-bit TQ</text>
+                    <text x="105" y="145" font-size="11" fill="#a0a0b0">50%</text>
+
+                    <!-- 5x compression -->
+                    <rect x="180" y="160" width="40" height="60" fill="#a78bfa" opacity="0.6"/>
+                    <text x="175" y="230" font-size="12" fill="#a78bfa" font-weight="600">2.5-bit TQ</text>
+                    <text x="170" y="155" font-size="11" fill="#a0a0b0">40%</text>
+
+                    <!-- PQ baseline -->
+                    <rect x="250" y="130" width="40" height="90" fill="#f87171" opacity="0.4"/>
+                    <text x="250" y="230" font-size="12" fill="#f87171" font-weight="600">4-bit PQ</text>
+                    <text x="245" y="125" font-size="11" fill="#a0a0b0">60%</text>
+                  </g>
+
+                  <!-- Y-axis label -->
+                  <text x="20" y="220" font-size="11" fill="#9696b0">0%</text>
+                  <text x="10" y="85" font-size="11" fill="#9696b0">100%</text>
+
+                  <!-- Legend -->
+                  <circle cx="60" cy="260" r="3" fill="#5e6ad2"/>
+                  <text x="70" y="264" font-size="11" fill="#a0a0b0">TurboQuant</text>
+
+                  <circle cx="270" cy="260" r="3" fill="#f87171"/>
+                  <text x="280" y="264" font-size="11" fill="#a0a0b0">Product Quantization</text>
+                </svg>
+                <div class="demo-stats">
+                  <div class="stat-box">
+                    <div class="stat-label">4-bit Compression</div>
+                    <div class="stat-value" id="compression4bit">4x</div>
+                  </div>
+                  <div class="stat-box">
+                    <div class="stat-label">Quality Loss</div>
+                    <div class="stat-value" id="qualityLoss">~2%</div>
+                  </div>
+                  <div class="stat-box">
+                    <div class="stat-label">Max Context Length</div>
+                    <div class="stat-value" id="contextLength">4x</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div id="search" class="tab-content">
+              <div class="demo">
+                <div class="demo-title">Vector Search Performance Comparison</div>
+                <svg class="demo-canvas" viewBox="0 0 500 280" style="height: 280px;">
+                  <!-- Background -->
+                  <rect width="500" height="280" fill="#1a1a2e"/>
+
+                  <!-- Metric 1: Recall -->
+                  <g>
+                    <text x="50" y="30" font-size="12" font-weight="600" fill="#a0a0b0">Recall@10</text>
+                    <rect x="40" y="50" width="50" height="100" fill="#5e6ad2" opacity="0.7"/>
+                    <text x="45" y="160" font-size="11" fill="#5e6ad2">TQ: 0.95</text>
+
+                    <rect x="110" y="55" width="50" height="95" fill="#f87171" opacity="0.6"/>
+                    <text x="110" y="160" font-size="11" fill="#f87171">PQ: 0.93</text>
+                  </g>
+
+                  <!-- Metric 2: Index Time -->
+                  <g>
+                    <text x="220" y="30" font-size="12" font-weight="600" fill="#a0a0b0">Index Time (ms)</text>
+                    <rect x="200" y="120" width="50" height="30" fill="#5e6ad2" opacity="0.7"/>
+                    <text x="205" y="160" font-size="11" fill="#5e6ad2">TQ: 8ms</text>
+
+                    <rect x="270" y="80" width="50" height="70" fill="#f87171" opacity="0.6"/>
+                    <text x="270" y="160" font-size="11" fill="#f87171">PQ: 20ms</text>
+                  </g>
+
+                  <!-- Metric 3: Memory -->
+                  <g>
+                    <text x="380" y="30" font-size="12" font-weight="600" fill="#a0a0b0">Memory (MB)</text>
+                    <rect x="360" y="70" width="50" height="80" fill="#5e6ad2" opacity="0.7"/>
+                    <text x="360" y="160" font-size="11" fill="#5e6ad2">TQ: 120</text>
+
+                    <rect x="430" y="65" width="50" height="85" fill="#f87171" opacity="0.6"/>
+                    <text x="425" y="160" font-size="11" fill="#f87171">PQ: 130</text>
+                  </g>
+
+                  <!-- Y-axis -->
+                  <line x1="190" y1="150" x2="190" y2="200" stroke="#2e2e3e" stroke-width="1"/>
+                </svg>
+                <div class="demo-stats">
+                  <div class="stat-box">
+                    <div class="stat-label">Recall Improvement</div>
+                    <div class="stat-value" id="recallImprovement">+2%</div>
+                  </div>
+                  <div class="stat-box">
+                    <div class="stat-label">Indexing Speedup</div>
+                    <div class="stat-value" id="speedup">2.5x</div>
+                  </div>
+                  <div class="stat-box">
+                    <div class="stat-label">Memory Savings</div>
+                    <div class="stat-value" id="memorySavings">8%</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="quiz">
+              <div class="quiz-title">Check Your Understanding</div>
+              <div class="quiz-question">What is the primary benefit of TurboQuant for LLM serving infrastructure?</div>
+              <div class="quiz-options">
+                <div class="quiz-option" data-correct="true">Reducing KV cache memory consumption, enabling longer context or higher batch sizes</div>
+                <div class="quiz-option" data-correct="false">Completely eliminating the need for key-value caching</div>
+                <div class="quiz-option" data-correct="false">Accelerating the transformer attention mechanism itself</div>
+                <div class="quiz-option" data-correct="false">Improving model accuracy on downstream tasks</div>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="completion">
+      <div class="completion-icon">🎓</div>
+      <h2>You've mastered TurboQuant!</h2>
+      <p>You now understand how vector quantization preserves geometric properties, the two-stage approach, random rotation for coordinate independence, theoretical guarantees, and real-world applications.</p>
+    </div>
+
+    <div style="max-width:920px;margin:0 auto 48px;padding:0 24px;">
+      <div style="border-top:1px solid #2e2e3e;padding-top:20px;display:flex;align-items:center;gap:8px;font-size:13px;color:#9696b0;">
+        <span>Learning Reference</span>
+        <span>·</span>
+        <a href="https://arxiv.org/html/2504.19874v1" target="_blank" rel="noopener"
+           style="color:#5e6ad2;text-decoration:none;font-weight:500;">TurboQuant: Online Vector Quantization (arXiv:2504.19874)</a>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Progress tracking
+    const sections = document.querySelectorAll('.section');
+    const progressFill = document.querySelector('.progress-fill');
+    const progressCount = document.querySelector('.progress-count');
+    const completion = document.querySelector('.completion');
+
+    function updateProgress() {
+      const openSections = document.querySelectorAll('.section.open').length;
+      const totalSections = sections.length;
+      const percentage = (openSections / totalSections) * 100;
+
+      progressFill.style.width = percentage + '%';
+      progressCount.textContent = openSections;
+
+      if (openSections === totalSections) {
+        completion.classList.add('show');
+      } else {
+        completion.classList.remove('show');
+      }
+    }
+
+    // Section collapse/expand
+    sections.forEach(section => {
+      const header = section.querySelector('.section-header');
+      header.addEventListener('click', () => {
+        section.classList.toggle('open');
+        updateProgress();
+      });
+    });
+
+    // Tab switching
+    document.querySelectorAll('.tab-button').forEach(button => {
+      button.addEventListener('click', () => {
+        const tab = button.dataset.tab;
+        const parent = button.closest('.section-body');
+
+        parent.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
+        parent.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+
+        button.classList.add('active');
+        parent.querySelector(`#${tab}`).classList.add('active');
+      });
+    });
+
+    // Quiz functionality
+    document.querySelectorAll('.quiz-option').forEach(option => {
+      option.addEventListener('click', () => {
+        const quiz = option.closest('.quiz');
+        const feedback = quiz.querySelector('.quiz-feedback');
+        const isCorrect = option.dataset.correct === 'true';
+
+        quiz.querySelectorAll('.quiz-option').forEach(o => {
+          o.classList.remove('selected', 'correct', 'incorrect');
+        });
+
+        option.classList.add('selected');
+        option.classList.add(isCorrect ? 'correct' : 'incorrect');
+
+        feedback.textContent = isCorrect
+          ? '✓ Correct! Well done.'
+          : '✗ Not quite. Try another option or re-read the explanation.';
+        feedback.classList.add('show', isCorrect ? 'success' : 'error');
+      });
+    });
+
+    // Bitwidth slider demo
+    const bitwidthSlider = document.getElementById('bitwidthSlider');
+    if (bitwidthSlider) {
+      bitwidthSlider.addEventListener('input', (e) => {
+        const bitwidth = parseInt(e.target.value);
+        const compressionRatio = (32 / bitwidth).toFixed(1);
+        const memorySaved = ((1 - bitwidth / 32) * 100).toFixed(0);
+        const errorRate = (Math.pow(bitwidth / 8, -0.5) * 30).toFixed(0);
+
+        document.getElementById('compressionRatio').textContent = compressionRatio + 'x';
+        document.getElementById('memorySaved').textContent = memorySaved + '%';
+        document.getElementById('errorRate').textContent = '~' + errorRate + '%';
+      });
+    }
+
+    // Initialize on load
+    updateProgress();
+  </script>
+</body>
+</html>

--- a/libs/portfolio/shell/feature/src/lib/app.component.ts
+++ b/libs/portfolio/shell/feature/src/lib/app.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, ErrorHandler, inject, Injectable, signal } from '@angular/core'
 import { RouterLink, RouterModule } from '@angular/router'
-import { FooterComponent, NavService } from '@dalenguyen/portfolio/shell/ui'
+import { FooterComponent, NavService, ThemeToggleComponent } from '@dalenguyen/portfolio/shell/ui'
 
 @Injectable()
 export class SentryErrorHandler implements ErrorHandler {
@@ -17,36 +17,34 @@ export class SentryErrorHandler implements ErrorHandler {
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'dalenguyen-root',
-  imports: [RouterModule, RouterLink, FooterComponent],
+  imports: [RouterModule, RouterLink, FooterComponent, ThemeToggleComponent],
   providers: [{ provide: ErrorHandler, useClass: SentryErrorHandler }],
   template: `
   <div class="flex flex-col min-h-screen">
     <!-- Header Navigation -->
-    <header class="bg-slate-800 shadow-lg">
+    <header class="sticky top-0 z-40 border-b border-border bg-bg/80 backdrop-blur-md supports-[backdrop-filter]:bg-bg/60">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
+        <div class="flex justify-between items-center h-16 gap-4">
           <!-- Logo and Brand -->
-          <div class="flex items-center">
-            <div class="flex-shrink-0 flex items-center">
-              <a routerLink="/" class="flex items-center">
-                <img class="h-8 w-8 rounded-full" src="/assets/images/dale-nguyen-avatar.webp" alt="Dale Nguyen" />
-              </a>
-            </div>
-          </div>
+          <a routerLink="/" class="flex items-center gap-2.5 shrink-0 group">
+            <img class="h-8 w-8 rounded-full ring-1 ring-border transition group-hover:ring-accent" src="/assets/images/dale-nguyen-avatar.webp" alt="Dale Nguyen" />
+            <span class="hidden sm:block text-sm font-semibold tracking-tight text-fg">Dale Nguyen</span>
+          </a>
 
           <!-- Desktop Navigation -->
-          <nav class="hidden md:flex items-center space-x-4">
+          <nav class="hidden lg:flex items-center gap-1">
             @for (item of navItems; track item) {
               <a
                 [id]="item.id + '-link'"
                 [routerLink]="item.route"
                 [fragment]="item.fragment"
-                [class.text-white]="isActive(item.id)"
-                [class.text-slate-300]="!isActive(item.id)"
-                class="px-3 py-2 rounded-md text-sm font-medium hover:bg-slate-700 hover:text-white transition duration-150 ease-in-out flex items-center"
+                [class.text-fg]="isActive(item.id)"
+                [class.bg-surface-2]="isActive(item.id)"
+                [class.text-fg-muted]="!isActive(item.id)"
+                class="px-3 py-2 rounded-lg text-sm font-medium hover:bg-surface-2 hover:text-fg transition-colors duration-150 flex items-center gap-1.5"
                 (click)="setActive(item.id)"
                 >
-                <svg class="w-5 h-5 mr-1" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <svg class="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" [attr.d]="item.svg" />
                 </svg>
                 {{ item.label }}
@@ -54,22 +52,21 @@ export class SentryErrorHandler implements ErrorHandler {
             }
           </nav>
 
-          <!-- Mobile menu button -->
-          <div class="flex md:hidden items-center">
+          <!-- Right side: theme toggle + mobile menu button -->
+          <div class="flex items-center gap-2">
+            <dalenguyen-theme-toggle />
             <button
               type="button"
-              class="inline-flex items-center justify-center p-2 rounded-md text-slate-400 hover:text-white hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
+              class="lg:hidden inline-flex items-center justify-center h-9 w-9 rounded-lg border border-border text-fg-muted hover:text-fg hover:bg-surface-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-colors"
               (click)="toggleMobileMenu()"
               [attr.aria-expanded]="isMobileMenuOpen()"
               aria-label="Toggle mobile menu"
               >
-              <!-- Icon when menu is closed -->
               @if (!isMobileMenuOpen()) {
                 <svg class="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
                 </svg>
               }
-              <!-- Icon when menu is open -->
               @if (isMobileMenuOpen()) {
                 <svg class="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -83,20 +80,20 @@ export class SentryErrorHandler implements ErrorHandler {
 
       <!-- Mobile menu, show/hide based on menu state -->
       @if (isMobileMenuOpen()) {
-        <div class="md:hidden">
+        <div class="lg:hidden border-t border-border bg-bg/95 backdrop-blur-md">
           <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
             @for (item of navItems; track item) {
               <a
                 [id]="item.id + '-mobile-link'"
                 [routerLink]="item.route"
                 [fragment]="item.fragment"
-                [class.bg-slate-900]="isActive(item.id)"
-                [class.text-white]="isActive(item.id)"
-                [class.text-slate-300]="!isActive(item.id)"
-                class="px-3 py-2 rounded-md text-base font-medium hover:bg-slate-700 hover:text-white transition duration-150 ease-in-out flex items-center"
+                [class.bg-surface-2]="isActive(item.id)"
+                [class.text-fg]="isActive(item.id)"
+                [class.text-fg-muted]="!isActive(item.id)"
+                class="px-3 py-2 rounded-lg text-base font-medium hover:bg-surface-2 hover:text-fg transition-colors duration-150 flex items-center gap-2"
                 (click)="setActive(item.id); toggleMobileMenu()"
                 >
-                <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" [attr.d]="item.svg" />
                 </svg>
                 {{ item.label }}
@@ -112,21 +109,12 @@ export class SentryErrorHandler implements ErrorHandler {
       <router-outlet />
     </main>
 
-    <!-- Footer - Using @defer to load after main content -->
+    <!-- Footer rendered directly: it's lightweight (text + one link), so eager
+         render keeps it in the SSR HTML and avoids a placeholder→footer layout
+         shift. -->
     <footer>
-      @defer (on immediate) {
       <dalenguyen-footer/>
-      } @placeholder {
-      <!-- Empty placeholder with same height to prevent layout shift -->
-      <div class="h-20 mx-auto w-full max-w-container px-4 sm:px-6 lg:px-8 flex items-center justify-center">
-        <div class="border-t border-slate-900/5 w-full">
-          <p class="text-center text-sm leading-6 text-slate-500">
-            Dale Nguyen © 2025 - By using Angular 20
-          </p>
-        </div>
-      </div>
-    }
-  </footer>
+    </footer>
   </div>
   `,
 })

--- a/libs/portfolio/shell/feature/src/lib/app.component.ts
+++ b/libs/portfolio/shell/feature/src/lib/app.component.ts
@@ -109,12 +109,10 @@ export class SentryErrorHandler implements ErrorHandler {
       <router-outlet />
     </main>
 
-    <!-- Footer rendered directly: it's lightweight (text + one link), so eager
-         render keeps it in the SSR HTML and avoids a placeholder→footer layout
-         shift. -->
-    <footer>
-      <dalenguyen-footer/>
-    </footer>
+    <!-- Footer rendered directly (lightweight) so it stays in the SSR HTML and
+         avoids a placeholder→footer layout shift. The component renders its own
+         <footer> landmark, so there is no wrapper here (avoids nested landmarks). -->
+    <dalenguyen-footer/>
   </div>
   `,
 })

--- a/libs/portfolio/shell/ui/src/index.ts
+++ b/libs/portfolio/shell/ui/src/index.ts
@@ -1,3 +1,5 @@
 export * from './lib/footer/footer.component'
 export * from './lib/nav/nav.component'
 export * from './lib/nav/nav.service'
+export * from './lib/theme-toggle/theme-toggle.component'
+export * from './lib/reveal/reveal.directive'

--- a/libs/portfolio/shell/ui/src/lib/footer/footer.component.ts
+++ b/libs/portfolio/shell/ui/src/lib/footer/footer.component.ts
@@ -14,7 +14,7 @@ import { ChangeDetectionStrategy, Component, VERSION } from '@angular/core'
           <a
             href="https://analogjs.org/"
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
             class="text-accent underline underline-offset-2"
             >Analog</a
           >

--- a/libs/portfolio/shell/ui/src/lib/footer/footer.component.ts
+++ b/libs/portfolio/shell/ui/src/lib/footer/footer.component.ts
@@ -4,13 +4,20 @@ import { ChangeDetectionStrategy, Component, VERSION } from '@angular/core'
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'dalenguyen-footer',
   template: `
-    <footer
-      class="border-t border-slate-900/5 mx-auto w-full max-w-container px-4 sm:px-6 lg:px-8 h-20 flex items-center justify-center"
-    >
-      <div class=" w-full">
-        <p class="text-center text-sm leading-6 text-slate-500">
-          Dale Nguyen © {{ currentYear }} - By using Angular {{ angularVersion }} &
-          <a href="https://analogjs.org/" target="_blank" rel="noopener">Analogjs</a>
+    <footer class="border-t border-border bg-bg">
+      <div class="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 py-6 flex flex-col sm:flex-row items-center justify-between gap-3">
+        <p class="text-sm leading-6 text-fg-muted">
+          Dale Nguyen © {{ currentYear }}
+        </p>
+        <p class="text-xs leading-6 text-fg-muted">
+          Built with Angular {{ angularVersion }} &amp;
+          <a
+            href="https://analogjs.org/"
+            target="_blank"
+            rel="noopener"
+            class="text-accent underline underline-offset-2"
+            >Analog</a
+          >
         </p>
       </div>
     </footer>

--- a/libs/portfolio/shell/ui/src/lib/reveal/reveal.directive.ts
+++ b/libs/portfolio/shell/ui/src/lib/reveal/reveal.directive.ts
@@ -1,0 +1,45 @@
+import { afterNextRender, DestroyRef, Directive, ElementRef, inject } from '@angular/core'
+
+/**
+ * Scroll-reveal as progressive enhancement. The server/no-JS render is fully
+ * visible; in the browser this defers only below-the-fold elements, fading them
+ * up as they enter the viewport. Above-the-fold content is left untouched (no
+ * flicker), and `prefers-reduced-motion` disables the effect entirely.
+ *
+ * `afterNextRender` only runs in the browser, so no platform guard is needed.
+ */
+@Directive({
+  selector: '[dalReveal]',
+  standalone: true,
+})
+export class RevealDirective {
+  private readonly el = inject<ElementRef<HTMLElement>>(ElementRef)
+  private readonly destroyRef = inject(DestroyRef)
+
+  constructor() {
+    afterNextRender(() => {
+      const node = this.el.nativeElement
+      const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      if (prefersReduced || !('IntersectionObserver' in window)) return
+
+      // Leave content that's already on screen visible; only animate what the
+      // reader will scroll to.
+      if (node.getBoundingClientRect().top < window.innerHeight * 0.9) return
+
+      node.classList.add('reveal')
+      const observer = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              node.classList.add('is-visible')
+              observer.unobserve(node)
+            }
+          }
+        },
+        { rootMargin: '0px 0px -10% 0px', threshold: 0.05 },
+      )
+      observer.observe(node)
+      this.destroyRef.onDestroy(() => observer.disconnect())
+    })
+  }
+}

--- a/libs/portfolio/shell/ui/src/lib/theme-toggle/theme-toggle.component.ts
+++ b/libs/portfolio/shell/ui/src/lib/theme-toggle/theme-toggle.component.ts
@@ -1,0 +1,67 @@
+import { afterNextRender, ChangeDetectionStrategy, Component, signal } from '@angular/core'
+
+/**
+ * Dark/light theme toggle. Dark is the default; an explicit choice is persisted
+ * to localStorage and applied as a `.light` class on <html> (an inline script in
+ * index.html applies it before first paint to avoid a flash).
+ *
+ * The signal starts `false` (dark) so the server render and the client's first
+ * (hydration) render agree; `afterNextRender` then syncs it to the real state.
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'dalenguyen-theme-toggle',
+  standalone: true,
+  template: `
+    <button
+      type="button"
+      (click)="toggle()"
+      [attr.aria-label]="isLight() ? 'Switch to dark theme' : 'Switch to light theme'"
+      title="Toggle theme"
+      class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border text-fg-muted hover:text-fg hover:bg-surface-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+    >
+      @if (isLight()) {
+        <!-- moon — click to switch to dark -->
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor" aria-hidden="true">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"
+          />
+        </svg>
+      } @else {
+        <!-- sun — click to switch to light -->
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor" aria-hidden="true">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"
+          />
+        </svg>
+      }
+    </button>
+  `,
+})
+export class ThemeToggleComponent {
+  readonly isLight = signal(false)
+
+  constructor() {
+    afterNextRender(() => {
+      this.isLight.set(document.documentElement.classList.contains('light'))
+    })
+  }
+
+  toggle(): void {
+    const next = !this.isLight()
+    this.isLight.set(next)
+
+    const root = document.documentElement
+    root.classList.toggle('light', next)
+    root.style.colorScheme = next ? 'light' : 'dark'
+    try {
+      localStorage.setItem('theme', next ? 'light' : 'dark')
+    } catch (e) {
+      /* private mode / storage disabled — non-fatal */
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Redesigns dalenguyen.me with a modern, minimal **dark-default** theme and a persisted **light toggle**, built on a semantic CSS-variable design-token system. Full overhaul of every routed surface, plus data-viz and motion.

## What's new
- **Theming**: dark `:root` + `.light` tokens mapped to semantic Tailwind colors; sun/moon toggle persisted to `localStorage`; FOUC-prevention inline script (SSR-safe).
- **Pages**: shell (glassy sticky header + footer), home (all sections; Portfolio + Publication de-Material'd), `/blog` list + post, `/learn`, bucket-list, 404, markdown routes.
- **Viz**: posts-per-year bar chart + category filters + reading time on `/blog` (build-time reading-time virtual manifest keeps post bodies out of the list bundle); theme-aware in-post `BarChartComponent`; bucket-list progress bar.
- **Motion**: hero entrance, animated accent glow, scroll-reveal directive — all `prefers-reduced-motion`-gated.

## Accessibility
- WCAG AA tokens; **Lighthouse 100 accessibility in both dark and light** (home + post).
- Fixed low-contrast muted text on standalone learn pages (`#7a7a99` → `#9696b0`).

## Fixes
- `PostAttributes.author` was typed as an object but is a string (byline rendered empty).
- Escaped literal `<img>`/`<picture>`/`<source>` in inline code in 3 posts (were emitting empty elements → image-alt failures); the all-green post is now 100 a11y.
- Removed 404 boilerplate; added home meta description; footer rendered directly (no placeholder layout shift).

## Verification
- `nx build blog-app` passes; all 50+ pages prerender.
- Lighthouse (desktop): home **100/100/100**, post **100/100/100** in dark + light.

## Notes
- Includes the previously-untracked `turboquant-vector-quantization.html` learn page (contrast-fixed).
- Pre-existing, out of scope: unit tests can't run (`jest.config.js` vs `.ts`); cover-image CLS is handled by the existing prod preload.

Design doc: `docs/plans/2026-06-14-dark-mode-redesign-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dark and light theme toggle with persistent preference storage
  * Reading time estimates for all blog posts
  * Category filter chips and year-based blog post grouping
  * Bucket list completion percentage tracker with progress bar
  * Scroll-reveal animations for interactive content
  * New interactive learning page on vector quantization
  * Improved 404 page with better navigation options

* **Improvements**
  * Redesigned blog and portfolio layouts with enhanced visual hierarchy
  * Updated color scheme across the site for improved contrast
  * Better post metadata display with category highlights
  * Enhanced footer and contact section styling
  * Improved accessibility with motion preferences support

* **Documentation**
  * Added dark-mode redesign design plan documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->