### PR TITLE
fix(learn): keyboard-accessible accordions + quiz state reset

### DIFF
--- a/apps/blog-app/src/plugins/learn-manifest.plugin.ts
+++ b/apps/blog-app/src/plugins/learn-manifest.plugin.ts
@@ -25,10 +25,49 @@ const NAV_HTML = `<link href="https://fonts.googleapis.com/icon?family=Material+
   <a href="/#contact"><span class="material-icons">email</span><span class="nav-label">Contact</span></a>
 </nav>`
 
+// Keyboard-accessibility enhancement injected into every learn page. The
+// generated accordion headers are <div>s (class `section-header` or
+// `section-head`), so this gives them button semantics (role + tabindex),
+// Enter/Space activation, an aria-expanded state synced to the section's
+// open/active class, and a visible focus ring. One place fixes all current and
+// future learn pages without editing the generated HTML.
+const A11Y_ADDON = `<!-- learn-a11y-start -->
+<style>.section-header:focus-visible,.section-head:focus-visible{outline:2px solid #818cf8;outline-offset:2px;border-radius:8px;}</style>
+<script>
+(function () {
+  function isOpen(h) {
+    for (var n = h; n && n !== document.body; n = n.parentElement) {
+      if (n.classList && (n.classList.contains('open') || n.classList.contains('active'))) return true;
+    }
+    return false;
+  }
+  function enhance() {
+    document.querySelectorAll('.section-header, .section-head').forEach(function (h) {
+      if (h.dataset.a11yEnhanced) return;
+      h.dataset.a11yEnhanced = '1';
+      h.setAttribute('role', 'button');
+      h.setAttribute('tabindex', '0');
+      h.setAttribute('aria-expanded', String(isOpen(h)));
+      h.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') { e.preventDefault(); h.click(); }
+      });
+      h.addEventListener('click', function () {
+        setTimeout(function () { h.setAttribute('aria-expanded', String(isOpen(h))); }, 0);
+      });
+    });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', enhance);
+  else enhance();
+})();
+</script>
+<!-- learn-a11y-end -->`
+
 function injectNav(html: string): string {
-  // Remove any previously injected nav to avoid duplicates
-  const cleaned = html.replace(/<link[^>]+Material\+Icons[^>]*>\s*<style>\s*#learn-app-nav[\s\S]*?<\/nav>/m, '')
-  return cleaned.replace('<body>', `<body>\n${NAV_HTML}`)
+  // Remove any previously injected nav/a11y blocks to avoid duplicates (dev re-injection)
+  const cleaned = html
+    .replace(/<link[^>]+Material\+Icons[^>]*>\s*<style>\s*#learn-app-nav[\s\S]*?<\/nav>/m, '')
+    .replace(/<!-- learn-a11y-start -->[\s\S]*?<!-- learn-a11y-end -->/m, '')
+  return cleaned.replace('<body>', `<body>\n${NAV_HTML}\n${A11Y_ADDON}`)
 }
 
 function scanLearnDir(dir: string) {

--- a/libs/portfolio/shared/learn/turboquant-vector-quantization.html
+++ b/libs/portfolio/shared/learn/turboquant-vector-quantization.html
@@ -1186,6 +1186,7 @@
         feedback.textContent = isCorrect
           ? '✓ Correct! Well done.'
           : '✗ Not quite. Try another option or re-read the explanation.';
+        feedback.classList.remove('success', 'error');
         feedback.classList.add('show', isCorrect ? 'success' : 'error');
       });
     });


### PR DESCRIPTION
Follow-up to #173 — resolves the two CodeRabbit findings on the standalone learn pages that were deferred there.

## What
- **Keyboard-accessible accordions (all 11 learn pages).** The generated accordion headers are `<div>`s in two patterns (`.section-header` + JS listener, and `.section-head` + inline `onclick`). Rather than hand-edit inconsistent generated HTML, the existing `learn-manifest` Vite plugin (which already injects the shared nav into every learn page) now also injects a small enhancement that gives every accordion header:
  - `role="button"` + `tabindex="0"`
  - **Enter/Space** activation (dispatches the existing click handler)
  - `aria-expanded` synced to the section's `open`/`active` class
  - a `:focus-visible` ring
  
  One pipeline change covers all current pages **and any future page**, with no edits to generated content.
- **Quiz feedback reset (turboquant).** Clear `success`/`error` classes before applying the new result so styling can't contradict the latest answer.

## Verification
- Enter expands `.section-header` sections (turboquant); Space expands `.section-head` sections (how-github-apps-work); `aria-expanded` flips correctly on both.
- `nx build blog-app` passes; the addon is injected into all **11** standalone learn pages exactly once (the Angular `/learn` route page is correctly untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)