### PR TITLE
docs(blog-app): add Cloud Run agent lesson callout to froze post

### DIFF
--- a/apps/blog-app/src/content/2026-07-09-the-background-task-that-froze.md
+++ b/apps/blog-app/src/content/2026-07-09-the-background-task-that-froze.md
@@ -10,6 +10,8 @@ author: Dale Nguyen
 draft: false
 ---
 
+> 💡 **Lesson learned building an agent on Cloud Run:** don't schedule work to run *after* you send the response. On Cloud Run's default request-based CPU mode it freezes mid-run — do the latency-critical work before you respond.
+
 I had a webhook receiver that acknowledged events in well under a second. Fast, clean, exactly what you want from a webhook handler. The problem was what happened *after* the ack: the job that receiving the webhook was supposed to launch showed up about three minutes later. Sometimes it showed up right away. Sometimes it never showed up at all — until something completely unrelated happened to hit the service, at which point the "stuck" job would suddenly, retroactively, complete.
 
 That last detail is what made it a genuine mystery for a while. A job that finishes the instant an unrelated request lands is not behaving like a slow job. It's behaving like something that was *frozen*, waiting for permission to keep running.


### PR DESCRIPTION
Adds a top-of-post callout to **The Background Task That Froze**, framing the CPU-throttling gotcha as a lesson learned building an agent on Cloud Run — matching the social infographic.

> 💡 Lesson learned building an agent on Cloud Run: don't schedule work to run after you send the response. On Cloud Run's default request-based CPU mode it freezes mid-run — do the latency-critical work before you respond.

Body-only markdown change; local `nx build blog-app` passes.

## Verify
- `/blog/2026-07-09-the-background-task-that-froze` on the Vercel preview — callout renders as a blockquote directly under the title/byline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Lesson learned” note explaining that background work scheduled after a response may pause under Cloud Run’s default CPU settings.
  * Clarified that latency-critical tasks should be completed before sending a response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->