### PR TITLE
fix(blog-app): reset scroll to top on route navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# dalenguyen.github.io
+
+Nx + pnpm monorepo behind Dale Nguyen's personal site, dalenguyen.me. The only actively-shipped app is the AnalogJS blog in `apps/blog-app`, which serves the whole site — see [`apps/blog-app/CLAUDE.md`](apps/blog-app/CLAUDE.md) for its blog-post, deploy, and verify workflow. Everything else under `apps/*` and `libs/*` is legacy or supporting code.

--- a/apps/blog-app/src/app/app.config.ts
+++ b/apps/blog-app/src/app/app.config.ts
@@ -14,7 +14,7 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideFileRouter(
       withRouterConfig({ onSameUrlNavigation: 'reload' }),
-      withInMemoryScrolling({ anchorScrolling: 'enabled' }),
+      withInMemoryScrolling({ scrollPositionRestoration: 'enabled', anchorScrolling: 'enabled' }),
       withComponentInputBinding(),
     ),
     provideClientHydration(withEventReplay()),


### PR DESCRIPTION
## Problem

Opening a new page scrolled it down to the previous page's scroll position instead of starting at the top.

## Root cause

The router was configured with `withInMemoryScrolling({ anchorScrolling: 'enabled' })` but never set **`scrollPositionRestoration`**, which defaults to `'disabled'`. With it disabled, Angular's router leaves the scroll offset untouched on navigation, so each new route inherited the previous page's scroll.

## Fix

```diff
- withInMemoryScrolling({ anchorScrolling: 'enabled' }),
+ withInMemoryScrolling({ scrollPositionRestoration: 'enabled', anchorScrolling: 'enabled' }),
```

`'enabled'` (rather than `'top'`) so forward navigations start at the top **and** the back/forward buttons still restore the prior scroll position.

## Verification (local dev)

| Action | scrollY | Result |
|---|---|---|
| Home scrolled to 2500 → click into a blog post | `0` | ✅ new page starts at top |
| Back button → Home | `2500` | ✅ previous position restored |

🤖 Generated with [Claude Code](https://claude.com/claude-code)