### PR TITLE
feat(skills): add newsletter-post skill (Resend announcement workflow)

### DIFF
--- a/.claude/skills/newsletter-post/SKILL.md
+++ b/.claude/skills/newsletter-post/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: newsletter-post
+description: This skill should be used to announce a newly published dalenguyen.me blog post to the Resend email newsletter — it composes an on-brand HTML announcement from the post's frontmatter, sends a test to a chosen address first, and only after explicit approval broadcasts to the subscriber audience. Triggers on requests like "email the new post to subscribers", "send the newsletter for this post", "announce this post to the list", "send it to the subscribers", or as the announce step after publishing a new post.
+---
+
+# Newsletter Post
+
+## Purpose
+
+Turn a freshly published blog post into an email announcement to the dalenguyen.me
+Resend newsletter audience. The flow is deliberately **test first, broadcast second**:
+send one preview email, let the human confirm it looks right, then send to the list.
+
+## When to use
+
+Use after a new post is **live** on the production site (Cloud Run — the email links
+to the live apex URL). If the post is not yet deployed, deploy it first
+(`nx run blog-app:deploy`, see `apps/blog-app/CLAUDE.md`) — the email must not link to
+a 404 or reference a cover image that has not shipped.
+
+## Inputs
+
+The post slug (or "the latest post"). If not given, use the newest
+`apps/blog-app/src/content/*.md` by date prefix. Read its frontmatter for `title`,
+`description`, `slug`, and `coverImage`. The live URL is
+`https://dalenguyen.me/blog/<slug>`.
+
+Also confirm a **test recipient address** with the user before sending (do not assume one).
+
+## Workflow
+
+### 1. Gather + verify the post
+
+Read the frontmatter (`title`, `description`, `slug`, `coverImage`). Then verify live,
+because a broken cover in an inbox is worse than on a page:
+
+```bash
+curl -s -A "Mozilla/5.0" -o /dev/null -w "%{http_code}\n" https://dalenguyen.me/blog/<slug>   # expect 200
+curl -s -A "Mozilla/5.0" -o /dev/null -w "%{content_type}\n" <coverImage-url>                 # expect image/*
+```
+
+If the cover returns `text/html`, the filename/URL is wrong or not deployed — fix before
+emailing (the blog uses date-prefixed image filenames that must match `coverImage`).
+
+### 2. Compose the email
+
+Copy `assets/email-template.html` to a working file (e.g. the scratchpad) and fill the tokens:
+
+| Token | Fill with |
+|---|---|
+| `{{TITLE}}` | post title |
+| `{{DESCRIPTION}}` | 1–2 sentence teaser (trim the frontmatter description) |
+| `{{COVER_IMAGE}}` | absolute live coverImage URL |
+| `{{URL}}` | `https://dalenguyen.me/blog/<slug>` |
+| `{{PREHEADER}}` | one punchy inbox-preview line |
+| `{{HIGHLIGHTS}}` | 2–4 `<li>…</li>` items — the most compelling specifics of THIS post (interactive widgets, a striking stat, a real result). Compose from the post content. |
+
+Leave `%%UNSUB%%` untouched — `resend_send.py` fills it per mode. Draft a subject line
+and propose it to the user (offer a punchier alternative).
+
+### 3. Preview (recommended)
+
+Render the working HTML to an image so the user sees it without opening an inbox
+(headless Chrome screenshot), and/or send it with the file tools.
+
+### 4. Send the TEST (always, before any broadcast)
+
+```bash
+python3 scripts/resend_send.py test --to <address> --html <working.html> --subject "<subject>"
+```
+
+Report the returned message id and ask the user to check that inbox (including
+Promotions/Spam). `resend_send.py` reads `RESEND_API_KEY` from env or fetches it from
+Secret Manager automatically — no need to export it.
+
+### 5. GATE — wait for explicit approval
+
+**Do not broadcast until the user explicitly approves after seeing the test.** A broadcast
+is an irreversible send to real subscribers. Treat "send it" / "looks good, send" as
+approval; if the user only reacts to the test without approving the broadcast, ask.
+
+### 6. Check reach, then broadcast
+
+```bash
+python3 scripts/resend_send.py audience                       # report the ACTIVE subscriber count
+python3 scripts/resend_send.py broadcast --html <working.html> --subject "<subject>" --name "<short label + date>"
+```
+
+`broadcast` creates the broadcast (swapping `%%UNSUB%%` for Resend's managed one-click
+unsubscribe tag) and sends it to the whole audience. Unsubscribed contacts are auto-skipped.
+Add `--draft` to create without sending if the user wants a final dashboard check.
+
+### 7. Confirm delivery
+
+```bash
+python3 scripts/resend_send.py status --broadcast <id>        # queued → sending → sent
+```
+
+Report the final `status: sent` + `sent_at`. Open/click analytics appear in the Resend
+dashboard, not in the API response.
+
+## Configuration and gotchas
+
+All config (audience id, from address, API-key location) and the non-obvious traps —
+notably that `api.resend.com` is behind Cloudflare and **403s (`error code: 1010`) any
+default library User-Agent**, and that broadcasts must use the `{{{RESEND_UNSUBSCRIBE_URL}}}`
+merge tag — live in `references/resend.md`. Read it before deviating from the script.

--- a/.claude/skills/newsletter-post/assets/email-template.html
+++ b/.claude/skills/newsletter-post/assets/email-template.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <title>{{TITLE}}</title>
+  </head>
+  <body style="background-color:#0b0f17;color:#e5e7eb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-size:16px;line-height:1.6;margin:0;padding:0;">
+    <!-- Preheader: the inbox preview snippet. Keep it punchy; it is hidden in the body. -->
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;">{{PREHEADER}}</div>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#0b0f17;margin:0;padding:0;width:100%;">
+      <tbody>
+        <tr>
+          <td align="center" style="padding:32px 16px;">
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="background-color:#111827;border-radius:12px;border:1px solid #1f2937;max-width:600px;width:100%;">
+              <tbody>
+                <tr>
+                  <td style="padding:32px;">
+
+                    <p style="color:#22d3ee;font-size:12px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;margin:0 0 16px 0;">New on the blog</p>
+
+                    <a href="{{URL}}" style="text-decoration:none;">
+                      <img src="{{COVER_IMAGE}}" alt="{{TITLE}}" width="536" style="width:100%;max-width:536px;height:auto;border-radius:8px;border:1px solid #1f2937;display:block;" />
+                    </a>
+
+                    <h1 style="color:#e5e7eb;font-size:24px;font-weight:800;line-height:1.3;margin:24px 0 12px 0;">{{TITLE}}</h1>
+
+                    <p style="color:#9ca3af;font-size:15px;margin:0 0 20px 0;">{{DESCRIPTION}}</p>
+
+                    <p style="color:#e5e7eb;font-size:15px;margin:0 0 8px 0;font-weight:600;">Inside the post:</p>
+                    <ul style="color:#9ca3af;font-size:15px;margin:0 0 24px 0;padding-left:20px;">
+                      {{HIGHLIGHTS}}
+                    </ul>
+
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 28px 0;">
+                      <tbody>
+                        <tr>
+                          <td style="background-color:#22d3ee;border-radius:8px;">
+                            <a href="{{URL}}" style="background-color:#22d3ee;border-radius:8px;color:#0b0f17;display:inline-block;font-size:15px;font-weight:700;padding:13px 22px;text-decoration:none;">Read the post &rarr;</a>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+
+                    <hr style="border:none;border-top:1px solid #1f2937;margin:24px 0;" />
+
+                    <p style="color:#9ca3af;font-size:12px;margin:0 0 8px 0;">
+                      You are receiving this because you subscribed at dalenguyen.me. I only email when there is something new worth your time.
+                    </p>
+                    <p style="color:#9ca3af;font-size:12px;margin:0;">
+                      <a href="%%UNSUB%%" style="color:#22d3ee;text-decoration:underline;">Unsubscribe</a>
+                    </p>
+
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/.claude/skills/newsletter-post/references/resend.md
+++ b/.claude/skills/newsletter-post/references/resend.md
@@ -1,0 +1,43 @@
+# Resend newsletter reference (dalenguyen.me)
+
+## Config (defaults baked into `scripts/resend_send.py`)
+
+| Key | Value | Notes |
+|---|---|---|
+| Audience | `1736935e-03b2-41a8-bfa8-e551ede7854b` (name: "General") | the blog newsletter list |
+| From | `Dale Nguyen <hello@news.dalenguyen.me>` | `news.dalenguyen.me` is the verified sending domain |
+| API key | Secret Manager secret `RESEND_API_KEY` in project `dalenguyen-prod` | read with account `dale@dalenguyen.me` |
+| Site | `https://dalenguyen.me` | used for the site's own unsubscribe URL in test mode |
+
+These are the same env vars the deployed blog uses (`RESEND_API_KEY`, `RESEND_AUDIENCE_ID`, `RESEND_FROM`), set on the Cloud Run service. The unsubscribe flow itself is handled by the app at `apps/blog-app/src/server/middleware/unsubscribe.ts` (PATCHes the Resend contact to `unsubscribed: true`).
+
+## Fetching the API key (never print it)
+
+```bash
+export RESEND_API_KEY=$(gcloud secrets versions access latest \
+  --secret=RESEND_API_KEY --project=dalenguyen-prod --account=dale@dalenguyen.me)
+```
+
+`resend_send.py` also fetches it automatically via this exact command if `RESEND_API_KEY` is not already in the env, so exporting it is optional.
+
+## Gotchas (each cost real time)
+
+- **Cloudflare blocks default library User-Agents.** `api.resend.com` sits behind Cloudflare; a request with the default `Python-urllib/*` (or any bot-looking) UA returns **HTTP 403 with body `error code: 1010`** — which looks like an auth failure but is a WAF block. `resend_send.py` sends a browser UA on every call. If scripting Resend any other way (curl/fetch from a plain client), set a browser `User-Agent` too.
+- **`error code: 1010` ≠ bad key.** Real Resend auth/validation errors are JSON (`{"statusCode":401,...}`). A bare `error code: NNNN` is Cloudflare, not Resend.
+- **Broadcasts require an unsubscribe mechanism.** Use Resend's managed merge tag `{{{RESEND_UNSUBSCRIBE_URL}}}` in the broadcast HTML (the script inserts it in `broadcast` mode). It renders a per-recipient one-click unsubscribe and auto-marks the contact unsubscribed. Do NOT hardcode a single unsubscribe URL in a broadcast.
+- **Broadcast status is `queued` immediately after send.** It transitions `queued → sending → sent` asynchronously (seconds for a small list). `sent_at` is null until it flips. Poll with `status --broadcast <id>` to confirm.
+- **Broadcasts auto-skip unsubscribed contacts.** The audience count includes unsubscribed contacts; the real reach is the "active" count from `audience` mode.
+- **Test vs broadcast are different endpoints.** `test` uses `POST /emails` (one transactional message, does not touch audience state). `broadcast` uses `POST /broadcasts` then `POST /broadcasts/{id}/send` (goes to the whole audience, has analytics).
+
+## Resend API endpoints used
+
+| Purpose | Call |
+|---|---|
+| Single/test email | `POST /emails` `{from,to[],subject,html,headers}` → `{id}` |
+| Audience meta | `GET /audiences/{id}` |
+| Audience contacts | `GET /audiences/{id}/contacts` → `{data:[{email,unsubscribed}]}` |
+| Create broadcast | `POST /broadcasts` `{audience_id,from,subject,name,html}` → `{id}` |
+| Send broadcast | `POST /broadcasts/{id}/send` `{}` (or `{scheduled_at}`) |
+| Broadcast status | `GET /broadcasts/{id}` → `{status,sent_at,...}` |
+
+Analytics (opens/clicks) for a sent broadcast appear in the Resend dashboard, not returned by the send call.

--- a/.claude/skills/newsletter-post/scripts/resend_send.py
+++ b/.claude/skills/newsletter-post/scripts/resend_send.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Send a blog-post announcement through Resend.
+
+Modes:
+  audience                       Print the audience name + active/unsubscribed counts (read-only).
+  test      --to EMAIL --html F  Send ONE transactional email (POST /emails) as a preview.
+  broadcast --html F             Create + send a Broadcast to the whole audience.
+  status    --broadcast ID       Print a broadcast's status + sent_at.
+
+The HTML file may contain the placeholder `%%UNSUB%%` for the unsubscribe href;
+this script fills it per mode:
+  - test      -> {SITE}/unsubscribe?email=<recipient>   (the site's own unsubscribe flow)
+  - broadcast -> {{{RESEND_UNSUBSCRIBE_URL}}}            (Resend-managed, one per recipient)
+
+Config resolves from env first, then falls back to the dalenguyen.me defaults:
+  RESEND_API_KEY       (if unset, fetched from Secret Manager via gcloud — see get_key)
+  RESEND_FROM          default: "Dale Nguyen <hello@news.dalenguyen.me>"
+  RESEND_AUDIENCE_ID   default: "1736935e-03b2-41a8-bfa8-e551ede7854b"
+  SITE_URL             default: "https://dalenguyen.me"
+
+Gotcha baked in: api.resend.com is behind Cloudflare, which 403s (error 1010)
+the default urllib/library User-Agent. Every request sends a browser UA.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API = "https://api.resend.com"
+UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/126.0 Safari/537.36")
+DEFAULT_FROM = "Dale Nguyen <hello@news.dalenguyen.me>"
+DEFAULT_AUDIENCE = "1736935e-03b2-41a8-bfa8-e551ede7854b"
+DEFAULT_SITE = "https://dalenguyen.me"
+SECRET_NAME = "RESEND_API_KEY"
+GCP_PROJECT = "dalenguyen-prod"
+GCP_ACCOUNT = "dale@dalenguyen.me"
+
+
+def get_key() -> str:
+    key = os.environ.get("RESEND_API_KEY", "").strip()
+    if key:
+        return key
+    # Fall back to Secret Manager (the key lives there; never print it).
+    try:
+        out = subprocess.run(
+            ["gcloud", "secrets", "versions", "access", "latest",
+             f"--secret={SECRET_NAME}", f"--project={GCP_PROJECT}", f"--account={GCP_ACCOUNT}"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+        sys.exit(f"ERROR: could not read {SECRET_NAME} from Secret Manager: {out.stderr.strip()[:200]}")
+    except Exception as e:  # noqa: BLE001
+        sys.exit(f"ERROR: RESEND_API_KEY not in env and gcloud fetch failed: {e}")
+
+
+def _req(method: str, path: str, key: str, payload=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {"Authorization": f"Bearer {key}", "User-Agent": UA}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(f"{API}{path}", data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, json.loads(r.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()[:400]
+        sys.exit(f"ERROR: {method} {path} -> HTTP {e.code}: {body}")
+
+
+def cmd_audience(args, key):
+    aud = args.audience
+    _, meta = _req("GET", f"/audiences/{aud}", key)
+    _, contacts = _req("GET", f"/audiences/{aud}/contacts", key)
+    data = contacts.get("data") or []
+    unsub = sum(1 for c in data if c.get("unsubscribed"))
+    print(f"audience: {meta.get('name')} ({aud})")
+    print(f"contacts: {len(data)} | unsubscribed: {unsub} | active: {len(data) - unsub}")
+
+
+def _fill(html_path: str, unsub_href: str) -> str:
+    html = open(html_path, encoding="utf-8").read()
+    if "%%UNSUB%%" not in html:
+        print("WARN: %%UNSUB%% placeholder not found in HTML — no unsubscribe link will be set.",
+              file=sys.stderr)
+    return html.replace("%%UNSUB%%", unsub_href)
+
+
+def cmd_test(args, key):
+    to = args.to
+    unsub = f"{args.site}/unsubscribe?email={urllib.parse.quote(to)}"
+    html = _fill(args.html, unsub)
+    st, body = _req("POST", "/emails", key, {
+        "from": args.sender, "to": [to], "subject": args.subject,
+        "html": html,
+        "headers": {"List-Unsubscribe": f"<{unsub}>",
+                    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
+    })
+    print(f"TEST sent status={st} id={body.get('id')} to={to} from={args.sender}")
+
+
+def cmd_broadcast(args, key):
+    html = _fill(args.html, "{{{RESEND_UNSUBSCRIBE_URL}}}")
+    st, created = _req("POST", "/broadcasts", key, {
+        "audience_id": args.audience, "from": args.sender,
+        "subject": args.subject, "name": args.name, "html": html,
+    })
+    bid = created.get("id")
+    if not bid:
+        sys.exit(f"ERROR: broadcast create returned no id: {created}")
+    print(f"broadcast created status={st} id={bid}")
+    if args.draft:
+        print("draft only (--draft) — NOT sent. Send later with the dashboard or a /send call.")
+        return
+    st2, sent = _req("POST", f"/broadcasts/{bid}/send", key, {})
+    print(f"broadcast SEND status={st2} id={bid}")
+
+
+def cmd_status(args, key):
+    _, b = _req("GET", f"/broadcasts/{args.broadcast}", key)
+    for k in ("id", "name", "status", "sent_at", "subject"):
+        if k in b:
+            print(f"  {k}: {b[k]}")
+
+
+def main():
+    p = argparse.ArgumentParser(description="Resend blog-post announcement sender")
+    p.add_argument("--sender", default=os.environ.get("RESEND_FROM", DEFAULT_FROM))
+    p.add_argument("--audience", default=os.environ.get("RESEND_AUDIENCE_ID", DEFAULT_AUDIENCE))
+    p.add_argument("--site", default=os.environ.get("SITE_URL", DEFAULT_SITE))
+    sub = p.add_subparsers(dest="mode", required=True)
+
+    sub.add_parser("audience")
+
+    t = sub.add_parser("test")
+    t.add_argument("--to", required=True)
+    t.add_argument("--html", required=True)
+    t.add_argument("--subject", required=True)
+
+    b = sub.add_parser("broadcast")
+    b.add_argument("--html", required=True)
+    b.add_argument("--subject", required=True)
+    b.add_argument("--name", required=True, help="internal label shown in the Resend dashboard")
+    b.add_argument("--draft", action="store_true", help="create the broadcast but do NOT send it")
+
+    s = sub.add_parser("status")
+    s.add_argument("--broadcast", required=True)
+
+    args = p.parse_args()
+    key = get_key()
+    {"audience": cmd_audience, "test": cmd_test, "broadcast": cmd_broadcast, "status": cmd_status}[args.mode](args, key)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a reusable `/newsletter-post` skill that turns "announce a new post to the newsletter" into a repeatable workflow.

## What it does
Given a post (or "the latest post"): verify it's live → compose an on-brand HTML email from frontmatter → send a **test** to a chosen address → **only after explicit approval**, broadcast to the Resend audience → confirm `sent`.

## Files
- `SKILL.md` — workflow with a mandatory test-first + approval gate
- `scripts/resend_send.py` — `test` | `broadcast` | `audience` | `status` (auto-fetches the key from Secret Manager, browser UA baked in)
- `assets/email-template.html` — dark on-brand template with `{{TOKENS}}` + `%%UNSUB%%`
- `references/resend.md` — audience id, from address, endpoints, and gotchas

## Learnings encoded (so they aren't re-discovered)
- `api.resend.com` is behind Cloudflare — a default library User-Agent gets a 403 `error code: 1010`; the script sends a browser UA
- broadcasts use Resend's managed `{{{RESEND_UNSUBSCRIBE_URL}}}` merge tag
- key read from Secret Manager (`dalenguyen-prod`), never printed
- cover-image content-type check catches the blank-cover trap

Validated with the skill-creator validator; smoke-tested live via read-only `audience` mode. Tooling-only change under `.claude/skills/` — does not affect the deployed site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a newsletter workflow for verifying content, previewing emails, obtaining approval, and sending broadcasts.
  * Added a responsive dark-themed newsletter email template with reusable content placeholders.
  * Added support for test emails, audience insights, broadcast sending, draft mode, and delivery status checks.
* **Documentation**
  * Added setup guidance, configuration details, and email delivery considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->