### PR TITLE
docs: improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # Dale Nguyen Portfolio Website
 
 An [Nx](https://nx.dev) monorepo powering [dalenguyen.me](https://dalenguyen.me) —
@@ -66,7 +68,7 @@ nx e2e <app>-e2e        # Cypress / Playwright
 nx storybook <project>  # Storybook
 ```
 
-Use `nx affected -t build|test|lint` to run only what changed against `origin/dev`.
+Use `nx affected -t build -t test -t lint --base=origin/dev` to run only what changed against `origin/dev`.
 
 ## Deployment
 


### PR DESCRIPTION
Makes one small, focused improvement to the existing README.

<!-- codemagpie-summary:start -->
## 🐦 codemagpie review

- Fixes the `nx affected` README command from the invalid single-target syntax `-t build|test|lint` to repeated target flags: `-t build -t test -t lint`.
- Adds an explicit `--base=origin/dev` so affected commands compare against the documented production base branch instead of Nx's default base.

<sub>Reviewed <code>516c405</code></sub>
<!-- codemagpie-summary:end -->