### PR TITLE
ci(blog-app): deploy to Cloud Run via GitHub Actions with WIF

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,121 @@
+# Deploys blog-app to Cloud Run (project dalenguyen-prod) via
+# `nx run blog-app:deploy` — the same command you'd run by hand. This
+# workflow does not know how to deploy anything itself; it just calls the
+# existing target in apps/blog-app/project.json (build-server -> build-docker
+# -> deploy) with GCLOUD_ACCOUNT pointed at a Workload Identity Federation
+# (WIF) service account instead of dale@dalenguyen.me.
+#
+# Required repo secrets (Settings -> Secrets and variables -> Actions):
+#   WIF_PROVIDER        projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github/providers/github-provider
+#   WIF_SERVICE_ACCOUNT github-deploy@dalenguyen-prod.iam.gserviceaccount.com
+#
+# (GCP_PROJECT is intentionally not used here — the nx deploy target already
+# hardcodes --project dalenguyen-prod, so there's nothing for it to fill in.)
+#
+# ---------------------------------------------------------------------------
+# ONE-TIME SETUP (run once by dale@dalenguyen.me, with gcloud auth'd against
+# dalenguyen-prod, BEFORE this workflow can succeed):
+# ---------------------------------------------------------------------------
+#
+# PROJECT=dalenguyen-prod
+# REPO=dalenguyen/dalenguyen.github.io
+#
+# # 1. Service account CI will impersonate. No key is ever created for it.
+# gcloud iam service-accounts create github-deploy \
+#   --display-name="GitHub Actions deploy (blog-app)" --project=$PROJECT
+#
+# SA=github-deploy@$PROJECT.iam.gserviceaccount.com
+#
+# # 2. Roles this deploy actually needs: Cloud Build submit (build-docker),
+# #    Artifact Registry push, Cloud Run deploy, and SA impersonation for
+# #    the Cloud Run runtime identity.
+# for R in roles/run.admin \
+#          roles/cloudbuild.builds.editor \
+#          roles/artifactregistry.writer \
+#          roles/iam.serviceAccountUser; do
+#   gcloud projects add-iam-policy-binding $PROJECT \
+#     --member="serviceAccount:$SA" --role=$R --condition=None
+# done
+#
+# # 3. Trust GitHub's OIDC issuer, scoped to this repo only.
+# gcloud iam workload-identity-pools create github \
+#   --location=global --project=$PROJECT
+#
+# gcloud iam workload-identity-pools providers create-oidc github-provider \
+#   --location=global --workload-identity-pool=github --project=$PROJECT \
+#   --issuer-uri="https://token.actions.githubusercontent.com" \
+#   --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref" \
+#   --attribute-condition="assertion.repository=='dalenguyen/dalenguyen.github.io' && assertion.ref=='refs/heads/dev'"
+#
+# #    (Hardening for later: repository/ref are mutable name claims. Once this
+# #    is proven working, prefer mapping+conditioning on the immutable
+# #    attribute.repository_id / attribute.repository_owner_id claims instead
+# #    — a deleted-and-recreated repo can't inherit the trust that way.)
+#
+# # 4. Let only this repo's provider impersonate the deploy SA.
+# PN=$(gcloud projects describe $PROJECT --format='value(projectNumber)')
+#
+# gcloud iam service-accounts add-iam-policy-binding $SA --project=$PROJECT \
+#   --role=roles/iam.workloadIdentityUser \
+#   --member="principalSet://iam.googleapis.com/projects/$PN/locations/global/workloadIdentityPools/github/attribute.repository/$REPO"
+#
+# # 5. Store the two values this workflow reads as repo secrets.
+# echo "projects/$PN/locations/global/workloadIdentityPools/github/providers/github-provider" \
+#   | gh secret set WIF_PROVIDER --repo $REPO
+# echo "$SA" | gh secret set WIF_SERVICE_ACCOUNT --repo $REPO
+#
+# Until these secrets exist, this workflow will run and fail at the
+# google-github-actions/auth step — that's expected and harmless: it does
+# not block merges to dev, it just means blog-app still needs a manual
+# `nx run blog-app:deploy`.
+# ---------------------------------------------------------------------------
+
+name: Deploy blog-app
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'apps/blog-app/**'
+      - 'libs/portfolio/shared/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+# One Cloud Run deploy at a time — a second one racing the first would be bad.
+concurrency:
+  group: deploy-blog-app
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy blog-app to Cloud Run
+        run: pnpm exec nx run blog-app:deploy
+        env:
+          # Overrides the dale@dalenguyen.me fallback baked into
+          # apps/blog-app/project.json's build-docker/deploy targets.
+          GCLOUD_ACCOUNT: ${{ secrets.WIF_SERVICE_ACCOUNT }}

--- a/apps/blog-app/CLAUDE.md
+++ b/apps/blog-app/CLAUDE.md
@@ -5,8 +5,10 @@ serves the public site:
 - **Cloud Run** (`dalenguyen-prod`) — **production: this is what serves
   `dalenguyen.me`.** Nitro `node-server`: prerendered routes served as static HTML,
   everything else SSR'd on demand, API routes live. Ship it with
-  `nx run blog-app:deploy` (see Deployment). Merging to `dev` does NOT update the
-  public site on its own — you must run the Cloud Run deploy.
+  `nx run blog-app:deploy` (see Deployment). Once `.github/workflows/deploy.yml`
+  has its WIF secrets configured (see Deployment), merging to `dev` with changes
+  under `apps/blog-app/**` or `libs/portfolio/shared/**` triggers this
+  automatically — otherwise you still must run the Cloud Run deploy by hand.
 - **Vercel** (project `analogjs-blog`) — **preview only.** Every PR gets a preview
   deploy (`analogjs-blog-git-<branch>-…vercel.app`) for verification; static SSG,
   every route prerendered. It is NOT the public apex.
@@ -44,6 +46,23 @@ Targets: `build-server` (node-server build), `build-docker` (stage `analog/` int
 `.cloudrun/` + Cloud Build), `deploy` (Cloud Run). Image: nginx-free `node:22-slim`
 running `analog/server/index.mjs`. Service URL:
 `https://blog-app-185772516206.us-central1.run.app`.
+
+### CI (Workload Identity Federation)
+
+`.github/workflows/deploy.yml` runs `nx run blog-app:deploy` in CI on push to
+`dev` (scoped to `apps/blog-app/**` and `libs/portfolio/shared/**`), using
+[Workload Identity Federation](https://github.com/google-github-actions/auth)
+instead of a stored key: `google-github-actions/auth@v2` mints short-lived
+credentials for a `github-deploy` service account, and the workflow sets
+`GCLOUD_ACCOUNT` on the deploy step to that service account so `gcloud` doesn't
+fall back to `dale@dalenguyen.me`.
+
+This requires a one-time GCP setup (IAM service account, workload identity pool
++ provider, `WIF_PROVIDER`/`WIF_SERVICE_ACCOUNT` repo secrets) that only
+dale@dalenguyen.me can run — exact commands are in the workflow file's header
+comment. Until that setup is done, the job fails harmlessly at the auth step;
+it doesn't block merges, it just means blog-app still needs a manual
+`nx run blog-app:deploy` after merging.
 
 ## Static vs SSR per route
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml`: runs the existing `nx run blog-app:deploy` target (build-server → build-docker → deploy) on push to `dev` (scoped to `apps/blog-app/**` and `libs/portfolio/shared/**`), authenticated via Workload Identity Federation instead of a stored key.
- No changes to `apps/blog-app/project.json` or `Dockerfile` — the deploy chain already existed; this just wires CI to call it, pointing `GCLOUD_ACCOUNT` at the WIF-impersonated service account instead of falling back to `dale@dalenguyen.me`.
- Updates `apps/blog-app/CLAUDE.md` to document the new CI path and its one-time setup dependency.

## Requires one-time setup before it can actually deploy
The workflow will fail harmlessly at the `google-github-actions/auth` step until these exist — it does **not** block merges, and `nx run blog-app:deploy` still works manually in the meantime:

1. Create the `github-deploy` service account on `dalenguyen-prod`.
2. Grant it `roles/run.admin`, `roles/cloudbuild.builds.editor`, `roles/artifactregistry.writer`, `roles/iam.serviceAccountUser`.
3. Create a Workload Identity Pool + OIDC provider trusting GitHub, scoped to `assertion.repository=='dalenguyen/dalenguyen.github.io' && assertion.ref=='refs/heads/dev'`.
4. Bind `roles/iam.workloadIdentityUser` on the SA to that pool's principal set.
5. `gh secret set WIF_PROVIDER` / `gh secret set WIF_SERVICE_ACCOUNT` with the resulting values.

Exact commands are in the workflow file's header comment. Only dale@dalenguyen.me can run these (needs gcloud auth against `dalenguyen-prod`).

## Behavior change to note
Previously `apps/blog-app/CLAUDE.md` stated merges to `dev` never auto-deploy the public site. Once the secrets above are configured, a merge touching `apps/blog-app/**` or `libs/portfolio/shared/**` **will** trigger a Cloud Run deploy automatically.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` parses cleanly
- [x] Confirmed `apps/blog-app/project.json` and `Dockerfile` are untouched
- [x] Confirmed `blog-app` is the only project with a real Cloud Run `deploy` target (grepped all `apps/*/project.json`, `libs/*/project.json`)
- [ ] Run the one-time GCP setup and confirm a real deploy succeeds end-to-end (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDYdcZEN2LVVHgadC5NPWU
