### PR TITLE
fix(blog): patch anchor navigation to respect base href

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "license": "MIT",
   "packageManager": "pnpm@10.32.1",
+  "pnpm": {
+    "patchedDependencies": {
+      "@analogjs/content@2.6.1": "patches/@analogjs__content@2.6.1.patch"
+    }
+  },
   "scripts": {
     "nx": "node --max-old-space-size=8192 ./node_modules/.bin/nx",
     "ng": "nx",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dalenguyen",
   "version": "1.0.0",
   "license": "MIT",
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "nx": "node --max-old-space-size=8192 ./node_modules/.bin/nx",
     "ng": "nx",

--- a/patches/@analogjs__content@2.6.1.patch
+++ b/patches/@analogjs__content@2.6.1.patch
@@ -1,0 +1,21 @@
+diff --git a/fesm2022/analogjs-content.mjs b/fesm2022/analogjs-content.mjs
+index 85fbf48aa853ca42392f9d8130de278d5fb345ce..ef7223e1940fb27ddc12eb17441484083a6be5da 100644
+--- a/fesm2022/analogjs-content.mjs
++++ b/fesm2022/analogjs-content.mjs
+@@ -23,7 +23,15 @@ class AnchorNavigationDirective {
+             hasTargetSelf(element) &&
+             !hasDownloadAttribute(element)) {
+             const { pathname, search, hash } = element;
+-            const url = this.location.normalize(`${pathname}${search}${hash}`);
++            // A `<base href>` makes fragment-only hrefs (e.g. "#some-id") resolve
++            // `pathname` to the base ("/") instead of the current document path,
++            // sending same-page anchor links to the wrong route. Use the current
++            // location's pathname for those instead.
++            const isFragmentOnly = element.getAttribute('href')?.startsWith('#');
++            const resolvedPathname = isFragmentOnly
++                ? this.document.location.pathname
++                : pathname;
++            const url = this.location.normalize(`${resolvedPathname}${search}${hash}`);
+             this.router.navigateByUrl(url);
+             return false;
+         }

--- a/patches/@analogjs__content@2.6.1.patch
+++ b/patches/@analogjs__content@2.6.1.patch
@@ -1,21 +1,25 @@
 diff --git a/fesm2022/analogjs-content.mjs b/fesm2022/analogjs-content.mjs
-index 85fbf48aa853ca42392f9d8130de278d5fb345ce..ef7223e1940fb27ddc12eb17441484083a6be5da 100644
+index 85fbf48aa853ca42392f9d8130de278d5fb345ce..d94d2d06d497d8093e1dfbad5ce2a74d8adbbf5a 100644
 --- a/fesm2022/analogjs-content.mjs
 +++ b/fesm2022/analogjs-content.mjs
-@@ -23,7 +23,15 @@ class AnchorNavigationDirective {
+@@ -23,7 +23,19 @@ class AnchorNavigationDirective {
              hasTargetSelf(element) &&
              !hasDownloadAttribute(element)) {
              const { pathname, search, hash } = element;
 -            const url = this.location.normalize(`${pathname}${search}${hash}`);
 +            // A `<base href>` makes fragment-only hrefs (e.g. "#some-id") resolve
-+            // `pathname` to the base ("/") instead of the current document path,
-+            // sending same-page anchor links to the wrong route. Use the current
-+            // location's pathname for those instead.
++            // `pathname`/`search` against the base ("/") instead of the current
++            // document, sending same-page anchor links to the wrong route (and
++            // dropping any existing query string). Use the current location for
++            // those instead.
 +            const isFragmentOnly = element.getAttribute('href')?.startsWith('#');
 +            const resolvedPathname = isFragmentOnly
 +                ? this.document.location.pathname
 +                : pathname;
-+            const url = this.location.normalize(`${resolvedPathname}${search}${hash}`);
++            const resolvedSearch = isFragmentOnly
++                ? this.document.location.search
++                : search;
++            const url = this.location.normalize(`${resolvedPathname}${resolvedSearch}${hash}`);
              this.router.navigateByUrl(url);
              return false;
          }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@analogjs/content@2.6.1':
-    hash: 12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55
+    hash: 7178e23f0096051bd61bfbd719f772b3a35f02d9173cf62455ac8ca1a69a13d9
     path: patches/@analogjs__content@2.6.1.patch
 
 importers:
@@ -15,10 +15,10 @@ importers:
     dependencies:
       '@analogjs/content':
         specifier: 2.6.1
-        version: 2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1)
+        version: 2.6.1(patch_hash=7178e23f0096051bd61bfbd719f772b3a35f02d9173cf62455ac8ca1a69a13d9)(19ba9adfe9a280cbd2b274087622deb1)
       '@analogjs/router':
         specifier: 2.6.1
-        version: 2.6.1(@analogjs/content@2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/router@20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7))
+        version: 2.6.1(@analogjs/content@2.6.1(patch_hash=7178e23f0096051bd61bfbd719f772b3a35f02d9173cf62455ac8ca1a69a13d9)(19ba9adfe9a280cbd2b274087622deb1))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/router@20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7))
       '@angular/animations':
         specifier: 20.3.4
         version: 20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))
@@ -18401,7 +18401,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@analogjs/content@2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1)':
+  '@analogjs/content@2.6.1(patch_hash=7178e23f0096051bd61bfbd719f772b3a35f02d9173cf62455ac8ca1a69a13d9)(19ba9adfe9a280cbd2b274087622deb1)':
     dependencies:
       '@angular/common': 20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7)
       '@angular/core': 20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)
@@ -18471,9 +18471,9 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@analogjs/router@2.6.1(@analogjs/content@2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/router@20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7))':
+  '@analogjs/router@2.6.1(@analogjs/content@2.6.1(patch_hash=7178e23f0096051bd61bfbd719f772b3a35f02d9173cf62455ac8ca1a69a13d9)(19ba9adfe9a280cbd2b274087622deb1))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/router@20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7))':
     dependencies:
-      '@analogjs/content': 2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1)
+      '@analogjs/content': 2.6.1(patch_hash=7178e23f0096051bd61bfbd719f772b3a35f02d9173cf62455ac8ca1a69a13d9)(19ba9adfe9a280cbd2b274087622deb1)
       '@angular/core': 20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)
       '@angular/router': 20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7)
       tslib: 2.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,21 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@analogjs/content@2.6.1':
+    hash: 12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55
+    path: patches/@analogjs__content@2.6.1.patch
+
 importers:
 
   .:
     dependencies:
       '@analogjs/content':
         specifier: 2.6.1
-        version: 2.6.1(19ba9adfe9a280cbd2b274087622deb1)
+        version: 2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1)
       '@analogjs/router':
         specifier: 2.6.1
-        version: 2.6.1(@analogjs/content@2.6.1(19ba9adfe9a280cbd2b274087622deb1))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/router@20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7))
+        version: 2.6.1(@analogjs/content@2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/router@20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7))
       '@angular/animations':
         specifier: 20.3.4
         version: 20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))
@@ -18396,7 +18401,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@analogjs/content@2.6.1(19ba9adfe9a280cbd2b274087622deb1)':
+  '@analogjs/content@2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1)':
     dependencies:
       '@angular/common': 20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7)
       '@angular/core': 20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)
@@ -18466,9 +18471,9 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@analogjs/router@2.6.1(@analogjs/content@2.6.1(19ba9adfe9a280cbd2b274087622deb1))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/router@20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7))':
+  '@analogjs/router@2.6.1(@analogjs/content@2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/router@20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7))':
     dependencies:
-      '@analogjs/content': 2.6.1(19ba9adfe9a280cbd2b274087622deb1)
+      '@analogjs/content': 2.6.1(patch_hash=12de9eacbb793fd3a3571b19a72df9f168fced2310e401f9030de80464edbb55)(19ba9adfe9a280cbd2b274087622deb1)
       '@angular/core': 20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)
       '@angular/router': 20.3.4(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(@angular/platform-browser@20.3.4(@angular/animations@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(@angular/common@20.3.4(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0))(rxjs@7.5.7))(@angular/core@20.3.17(@angular/compiler@20.3.4)(rxjs@7.5.7)(zone.js@0.15.0)))(rxjs@7.5.7)
       tslib: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-patchedDependencies:
-  '@analogjs/content@2.6.1': patches/@analogjs__content@2.6.1.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  '@analogjs/content@2.6.1': patches/@analogjs__content@2.6.1.patch


### PR DESCRIPTION
## Summary
- In-page markdown anchor links (e.g. "section 03" in the Deploy What Changed post) navigated to the home page instead of scrolling to the target heading.
- Root cause: `@analogjs/content`'s `AnchorNavigationDirective` builds its target URL from `element.pathname`, but `apps/blog-app/index.html`'s `<base href="/">` resolves fragment-only hrefs (`#03-the-graph`) to `pathname === "/"`. The directive then calls `router.navigateByUrl("/#03-the-graph")`, landing on the home route where the fragment doesn't exist.
- Fixed via `pnpm patch @analogjs/content@2.6.1`: fall back to `document.location.pathname` when the raw `href` starts with `#`.

## Test plan
- [x] Ran the blog-app dev server, navigated to `/blog/2026-08-30-deploy-what-changed`, confirmed `a[href="#03-the-graph"].pathname` was `"/"` before the patch (reproduced the bug).
- [x] Clicked the "section 03" link — now navigates to `/blog/2026-08-30-deploy-what-changed#03-the-graph` and scrolls the `03. The graph` heading into view.
- [x] Verified the other post with an in-page anchor (`2026-05-30-local-first-...#model-options-by-available-ram`) also resolves correctly.
- [x] `pnpm install` reapplies the patch cleanly from a fresh checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDYdcZEN2LVVHgadC5NPWU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed same-page anchor links so they remain on the current page when a base URL is configured.
  * Preserved existing navigation behavior for other link types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->