### PR TITLE
fix(ci): stop pinning pnpm version in the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,9 +112,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No `version:` here on purpose. package.json's "packageManager" field is
+      # the single source of truth; specifying both makes pnpm/action-setup@v4
+      # fail with "Multiple versions of pnpm specified".
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
**Every deploy to `dev` has failed since #247 landed.** The blog post merged in #249 is not the cause — it was just the first push to `dev` since then.

## The failure

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.32.1 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors
```

Run [34522183284](https://github.com/dalenguyen/dalenguyen.github.io/actions/runs/34522183284). It fails at `Run pnpm/action-setup@v4`, before checkout's dependencies are installed and long before anything is built, so it is independent of the change being deployed.

## Cause

| | |
|---|---|
| `package.json:5` | `"packageManager": "pnpm@10.32.1"` — added by #247 on 2026-08-30 |
| `.github/workflows/deploy.yml:117` | `version: 10` — still passed to `pnpm/action-setup@v4` |

`pnpm/action-setup@v4` refuses to run when both are set.

The last green deploy was #241 on 2026-08-30, which merged **before** #247 added the `packageManager` field. Nothing has reached Cloud Run since.

## Fix

Drop `version` and let `packageManager` be the single source of truth, which is what `pnpm/action-setup` recommends. Also checked the repo's other workflows — none pass both.

## Effect

`dalenguyen.me` is currently serving the state from 2026-08-30. Merging this should let the deploy run and pick up #249's post along with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rKDZEaTZ7zHS7wk1a3ZFN

<!-- codemagpie-summary:start -->
## 🐦 codemagpie review

- Removes the explicit `version: 10` input from `pnpm/action-setup@v4` in `.github/workflows/deploy.yml`.
- Relies on the root `package.json` `"packageManager": "pnpm@10.32.1"` field to select the pnpm version.
- Adds a comment explaining why no `version:` input is used, preventing future duplicate-version failures.

<sub>Reviewed <code>b5b344b</code></sub>
<!-- codemagpie-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to use the package manager version specified by the project configuration, preventing version conflicts during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->